### PR TITLE
Build site once, use it for goreleaser and docker

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,30 @@ env:
   NODE_VERSION: '22'
 
 jobs:
+  build-site:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build frontend
+        run: make build-frontend
+
+      - name: Upload site build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-build
+          path: internal/static/build
+          retention-days: 1
+
   goreleaser:
     runs-on: ubuntu-latest
+    needs: build-site
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,18 +47,16 @@ jobs:
       - name: Fetch all tags
         run: git fetch --force --tags
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - name: Download site build artifacts
+        uses: actions/download-artifact@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          name: site-build
+          path: internal/static/build
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Build frontend
-        run: make build-frontend
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -49,9 +69,16 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    needs: build-site
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download site build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: site-build
+          path: internal/static/build
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,3 @@
-FROM node:22-alpine AS build-frontend
-
-WORKDIR /app/site
-
-# Copy package files first for better layer caching
-COPY site/package.json site/package-lock.json ./
-
-# Use npm ci for faster, more reliable installs and mount cache for npm packages
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --only=production --no-audit
-
-# Copy source files and build
-COPY site/ ./
-
-RUN npm run build
-
 FROM golang:1.24-alpine AS build-backend
 
 WORKDIR /build
@@ -26,11 +10,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 # Copy only necessary source directories
+# NOTE: internal/static/build should be pre-built and included in the build context
 COPY cmd/ cmd/
 COPY internal/ internal/
-
-# Copy frontend build artifacts from previous stage
-COPY --from=build-frontend /app/site/build internal/static/build
 
 # Build with optimizations for smaller binary
 RUN CGO_ENABLED=0 GOOS=linux go build \


### PR DESCRIPTION
## Summary

The site is arch agnostic, so it's a waste to build it three times.

## Changes

Moved the site build to a first step in the release pipeline, and then it's used for the goreleaser and docker steps.

## Testing

Testing??

## Checklist

- [x] Tests added/updated
- [x] Linters pass (`golangci-lint run`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated (if needed)
