### PR TITLE
Set version in binaries with goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 tmp/
 build-errors.log
 config.yaml
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,11 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w
+      - -X 'main.Version={{.Version}}'
+      - -X 'main.BuildTime={{.Date}}'
+      - -X 'main.GitCommit={{.ShortCommit}}'
 
 archives:
   - format: tar.gz
@@ -30,7 +35,7 @@ archives:
 
 checksum:
   name_template: 'checksums.txt'
-
+`
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
## Summary

Binaries created by goreleaser didn't have the version, this fixes that.

## Changes

- Update goreleaser spec to set version, like in the makefile

## Testing

Ran goreleaser locally.

## Checklist

- [x] Tests added/updated
- [x] Linters pass (`golangci-lint run`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated (if needed)
