### PR TITLE
feat: add make docker target and optimize Docker build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 .gitignore
 
 # Build artifacts
-bin/
 site/build/
 dist/
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,6 +146,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           ARCH: ${{ matrix.nfpm_arch }}
         run: |
+          mkdir -p dist
           nfpm package --packager ${{ matrix.format }} --target dist/
 
       - name: Upload package artifacts
@@ -157,7 +158,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-packages]
+    needs: [build-binaries, build-packages, docker-manifest]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -277,9 +278,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker-build:
+  build-docker:
     runs-on: ${{ matrix.runner }}
-    needs: build-frontend
+    needs: [build-frontend, build-binaries]
     strategy:
       matrix:
         include:
@@ -298,6 +299,15 @@ jobs:
         with:
           name: site-build
           path: internal/static/build
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: binary-linux-${{ matrix.arch }}
+          path: bin
+
+      - name: Make binary executable
+        run: chmod +x bin/solar-controller
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -341,9 +351,17 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Cleanup orphaned images on failure
+        if: failure()
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-untagged: true
+          delete-ghost-images: true
+
   docker-manifest:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: build-docker
     steps:
       - name: Download digests
         uses: actions/download-artifact@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,7 @@
-FROM golang:1.24-trixie AS build-backend
-
-WORKDIR /build
-
-# Copy go module files first for better layer caching
-COPY go.mod go.sum ./
-
-# Download dependencies with mount cache
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
-
-# Copy only necessary source directories
-# NOTE: internal/static/build should be pre-built and included in the build context
-COPY cmd/ cmd/
-COPY internal/ internal/
-
-# Build with CGO enabled (required for Solace library)
-RUN CGO_ENABLED=1 GOOS=linux go build \
-    -ldflags="-w -s" \
-    -o /go/bin/solar-controller \
-    ./cmd/controller
-
 FROM debian:trixie-slim
 
-COPY --from=build-backend /go/bin/solar-controller /
+# Copy pre-built binary from build context
+COPY bin/solar-controller /
 
 ENV GIN_MODE=release
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test clean build-frontend build-backend build-with-cgo build-linux-arm64 deploy
+.PHONY: help build test clean build-frontend build-backend build-with-cgo build-linux-arm64 docker deploy
 
 .DEFAULT_GOAL := help
 
@@ -40,6 +40,9 @@ clean: ## Clean build artifacts
 	rm -f bin/solar-controller-linux-arm64
 	rm -rf site/build
 	rm -rf internal/static/build
+
+docker: ## Build Docker image
+	docker build -t solar-controller:$(VERSION) -t solar-controller:latest .
 
 deploy: build-linux-arm64 ## Deploy to remote server (requires REMOTE_HOST=user@host)
 	@if [ -z "$(REMOTE_HOST)" ]; then \


### PR DESCRIPTION
## Summary

This PR adds a convenient `make docker` target to the Makefile and optimizes the CI/CD Docker build process to use pre-built binaries instead of rebuilding from source in the Dockerfile.

## Changes

- Added `make docker` target that builds Docker images with version and latest tags
- Modified Dockerfile to use pre-built binaries from the build context instead of multi-stage build
- Updated release workflow to download pre-built binaries before Docker build
- Updated `.dockerignore` to include `bin/` directory in Docker context
- Renamed `docker-build` job to `build-docker` for consistency
- Added `docker-manifest` as a dependency for `create-release` job
- Added cleanup action for orphaned Docker images on failure

## Testing

- Tested locally with `make docker` target
- CI/CD workflow validates Docker build process

## Checklist

- [ ] Tests added/updated
- [ ] Linters pass (`golangci-lint run`)
- [ ] Build succeeds (`make build`)
- [ ] Documentation updated (if needed)