### PR TITLE
fix: download only required artifacts in create-release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,9 +165,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download all artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v6
         with:
+          pattern: binary-*
+          path: artifacts
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: package-*
           path: artifacts
 
       - name: Organize release assets


### PR DESCRIPTION
## Summary

Fixes the release workflow failure in the `create-release` job by downloading only the artifacts needed for creating the GitHub release, rather than attempting to download all artifacts including Docker build cache artifacts.

## Changes

- Modified `create-release` job to use pattern-based artifact downloads
- Split artifact download into two steps: one for binary artifacts (`binary-*`) and one for package artifacts (`package-*`)
- Eliminates downloading Docker buildx cache and digest artifacts that caused download failures

## Testing

- Workflow changes will be tested by the next release tag push
- The fix addresses the artifact download timeout issue seen in workflow run #19194722715

## Checklist

- [x] Tests added/updated (N/A - workflow-only change)
- [x] Linters pass (N/A - YAML workflow change)
- [x] Build succeeds (N/A - workflow-only change)
- [x] Documentation updated (if needed) (N/A - self-explanatory workflow change)