### PR TITLE
refactor: enable multiple message publishers simultaneously

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,12 +18,12 @@ func TestLoad(t *testing.T) {
 			yaml: `
 solarController:
   httpPort: 8080
-  topicPrefix: solar/metrics
   mqtt:
     enabled: true
     host: mqtt://localhost:1883
     username: user
     password: pass
+    topicPrefix: solar/metrics
   epever:
     enabled: true
     serialPort: /dev/ttyUSB0
@@ -40,8 +40,8 @@ solarController:
 				if c.SolarController.Mqtt.Host != "mqtt://localhost:1883" {
 					t.Errorf("MQTT Host = %s, want mqtt://localhost:1883", c.SolarController.Mqtt.Host)
 				}
-				if c.SolarController.TopicPrefix != "solar/metrics" {
-					t.Errorf("TopicPrefix = %s, want solar/metrics", c.SolarController.TopicPrefix)
+				if c.SolarController.Mqtt.TopicPrefix != "solar/metrics" {
+					t.Errorf("MQTT TopicPrefix = %s, want solar/metrics", c.SolarController.Mqtt.TopicPrefix)
 				}
 				if !c.SolarController.Epever.Enabled {
 					t.Error("Epever should be enabled")
@@ -194,8 +194,8 @@ solarController:
 `,
 			wantErr: false,
 			check: func(t *testing.T, c Config) {
-				if c.SolarController.TopicPrefix != "solar" {
-					t.Errorf("TopicPrefix = %s, want solar (default)", c.SolarController.TopicPrefix)
+				if c.SolarController.Mqtt.TopicPrefix != "solar" {
+					t.Errorf("MQTT TopicPrefix = %s, want solar (default)", c.SolarController.Mqtt.TopicPrefix)
 				}
 			},
 		},
@@ -255,12 +255,12 @@ solarController:
 			yaml: `
 solarController:
   httpPort: 8080
-  topicPrefix: home/solar
   mqtt:
     enabled: true
     host: mqtt://broker.example.com:1883
     username: solaruser
     password: secretpassword
+    topicPrefix: home/solar
   epever:
     enabled: false
 `,
@@ -274,6 +274,9 @@ solarController:
 				}
 				if c.SolarController.Mqtt.Password != "secretpassword" {
 					t.Errorf("MQTT Password = %s, want secretpassword", c.SolarController.Mqtt.Password)
+				}
+				if c.SolarController.Mqtt.TopicPrefix != "home/solar" {
+					t.Errorf("MQTT TopicPrefix = %s, want home/solar", c.SolarController.Mqtt.TopicPrefix)
 				}
 			},
 		},
@@ -297,13 +300,13 @@ someOtherConfig:
 			yaml: `
 solarController:
   httpPort: 8080
-  topicPrefix: solar/metrics
   solace:
     enabled: true
     host: tcp://solace-broker:55555
     username: solaceuser
     password: solacepass
     vpnName: default
+    topicPrefix: solar/metrics
   epever:
     enabled: false
 `,
@@ -324,8 +327,8 @@ solarController:
 				if c.SolarController.Solace.VpnName != "default" {
 					t.Errorf("Solace VpnName = %s, want default", c.SolarController.Solace.VpnName)
 				}
-				if c.SolarController.TopicPrefix != "solar/metrics" {
-					t.Errorf("TopicPrefix = %s, want solar/metrics", c.SolarController.TopicPrefix)
+				if c.SolarController.Solace.TopicPrefix != "solar/metrics" {
+					t.Errorf("Solace TopicPrefix = %s, want solar/metrics", c.SolarController.Solace.TopicPrefix)
 				}
 			},
 		},
@@ -334,7 +337,6 @@ solarController:
 			yaml: `
 solarController:
   httpPort: 8080
-  topicPrefix: solar/metrics
   solace:
     enabled: true
     host: ""
@@ -350,7 +352,6 @@ solarController:
 			yaml: `
 solarController:
   httpPort: 8080
-  topicPrefix: solar/metrics
   solace:
     enabled: true
     host: tcp://solace-broker:55555
@@ -375,8 +376,8 @@ solarController:
 `,
 			wantErr: false,
 			check: func(t *testing.T, c Config) {
-				if c.SolarController.TopicPrefix != "solar" {
-					t.Errorf("TopicPrefix = %s, want solar (default)", c.SolarController.TopicPrefix)
+				if c.SolarController.Solace.TopicPrefix != "solar" {
+					t.Errorf("Solace TopicPrefix = %s, want solar (default)", c.SolarController.Solace.TopicPrefix)
 				}
 			},
 		},
@@ -393,24 +394,29 @@ solarController:
 			wantErr: false,
 		},
 		{
-			name: "Both MQTT and Solace enabled - should error",
+			name: "Both MQTT and Solace enabled - should succeed (multi-publisher support)",
 			yaml: `
 solarController:
   httpPort: 8080
   mqtt:
     enabled: true
     host: mqtt://localhost:1883
-    topicPrefix: solar/metrics
   solace:
     enabled: true
     host: tcp://solace-broker:55555
     vpnName: default
-    topicPrefix: solar/metrics
   epever:
     enabled: false
 `,
-			wantErr: true,
-			errMsg:  "only one publisher can be enabled at a time",
+			wantErr: false,
+			check: func(t *testing.T, c Config) {
+				if !c.SolarController.Mqtt.Enabled {
+					t.Error("MQTT should be enabled")
+				}
+				if !c.SolarController.Solace.Enabled {
+					t.Error("Solace should be enabled")
+				}
+			},
 		},
 	}
 

--- a/internal/file/publisher.go
+++ b/internal/file/publisher.go
@@ -17,12 +17,11 @@ type Configuration struct {
 }
 
 type Publisher struct {
-	logger      *lumberjack.Logger
-	config      Configuration
-	topicPrefix string
+	logger *lumberjack.Logger
+	config Configuration
 }
 
-func NewPublisher(config *Configuration, topicPrefix string) (*Publisher, error) {
+func NewPublisher(config *Configuration) (*Publisher, error) {
 	if !config.Enabled {
 		log.Info("File publisher disabled via configuration")
 		return &Publisher{}, nil
@@ -56,9 +55,8 @@ func NewPublisher(config *Configuration, topicPrefix string) (*Publisher, error)
 		config.Filename, maxSize, maxBackups, config.Compress)
 
 	publisher := &Publisher{
-		logger:      logger,
-		config:      *config,
-		topicPrefix: topicPrefix,
+		logger: logger,
+		config: *config,
 	}
 
 	return publisher, nil
@@ -69,12 +67,9 @@ func (p *Publisher) Publish(topicSuffix, payload string) {
 		return
 	}
 
-	// Create full topic with prefix
-	topic := fmt.Sprintf("%s/%s", p.topicPrefix, topicSuffix)
-
 	// Write the message as a single line with timestamp
 	timestamp := time.Now().Format(time.RFC3339)
-	line := fmt.Sprintf(`{"timestamp":"%s","topic":"%s","payload":%s}`+"\n", timestamp, topic, payload)
+	line := fmt.Sprintf(`{"timestamp":"%s","topic":"%s","payload":%s}`+"\n", timestamp, topicSuffix, payload)
 
 	if _, err := p.logger.Write([]byte(line)); err != nil {
 		log.Errorf("failed to write to log file: %v", err)

--- a/internal/file/publisher_test.go
+++ b/internal/file/publisher_test.go
@@ -13,7 +13,7 @@ func TestNewPublisher_Disabled(t *testing.T) {
 		Enabled: false,
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -29,7 +29,7 @@ func TestNewPublisher_NoFilename(t *testing.T) {
 		Filename: "",
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -48,7 +48,7 @@ func TestNewPublisher_WithDefaults(t *testing.T) {
 		Filename: filename,
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -79,7 +79,7 @@ func TestNewPublisher_WithCustomConfig(t *testing.T) {
 		Compress:   true,
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -107,14 +107,14 @@ func TestPublish(t *testing.T) {
 		Filename: filename,
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	defer publisher.Close()
 
 	// Publish a test message
-	topicSuffix := "epever/battery-voltage"
+	topicSuffix := "controller-1/epever/battery-voltage"
 	payload := `{"value":12.5,"unit":"volts","timestamp":1699000000}`
 
 	publisher.Publish(topicSuffix, payload)
@@ -126,7 +126,7 @@ func TestPublish(t *testing.T) {
 	}
 
 	content := string(data)
-	expectedTopic := "test/prefix/epever/battery-voltage"
+	expectedTopic := "controller-1/epever/battery-voltage"
 	if !strings.Contains(content, expectedTopic) {
 		t.Errorf("expected log to contain topic %q, got %q", expectedTopic, content)
 	}
@@ -175,7 +175,7 @@ func TestPublish_MultipleMessages(t *testing.T) {
 		Filename: filename,
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -186,9 +186,9 @@ func TestPublish_MultipleMessages(t *testing.T) {
 		topic   string
 		payload string
 	}{
-		{"epever/battery-voltage", `{"value":12.5,"unit":"volts"}`},
-		{"epever/battery-current", `{"value":5.2,"unit":"amperes"}`},
-		{"epever/battery-soc", `{"value":85,"unit":"percent"}`},
+		{"controller-1/epever/battery-voltage", `{"value":12.5,"unit":"volts"}`},
+		{"controller-1/epever/battery-current", `{"value":5.2,"unit":"amperes"}`},
+		{"controller-1/epever/battery-soc", `{"value":85,"unit":"percent"}`},
 	}
 
 	for _, msg := range messages {
@@ -214,7 +214,7 @@ func TestPublish_MultipleMessages(t *testing.T) {
 			t.Fatalf("failed to parse line %d: %v", i, err)
 		}
 
-		expectedTopic := "test/prefix/" + messages[i].topic
+		expectedTopic := messages[i].topic
 		if logEntry.Topic != expectedTopic {
 			t.Errorf("line %d: expected topic %q, got %q", i, expectedTopic, logEntry.Topic)
 		}
@@ -226,11 +226,11 @@ func TestPublish_DisabledPublisher(t *testing.T) {
 		Enabled: false,
 	}
 
-	publisher, err := NewPublisher(config, "test/prefix")
+	publisher, err := NewPublisher(config)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	// Should not panic when publishing to disabled publisher
-	publisher.Publish("test/topic", `{"value":123}`)
+	publisher.Publish("controller-1/test/topic", `{"value":123}`)
 }

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Configuration struct {
-	Enabled  bool   `yaml:"enabled"`
-	Host     string `yaml:"host"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Enabled     bool   `yaml:"enabled"`
+	Host        string `yaml:"host"`
+	Username    string `yaml:"username"`
+	Password    string `yaml:"password"`
+	TopicPrefix string `yaml:"topicPrefix"` // Optional: overrides global topicPrefix
 }
 
 type Publisher struct {

--- a/internal/publishers/factory_test.go
+++ b/internal/publishers/factory_test.go
@@ -18,10 +18,10 @@ func TestNewPublisher(t *testing.T) {
 		{
 			name: "MQTT enabled but no host - returns empty MQTT publisher",
 			config: config.SolarControllerConfiguration{
-				TopicPrefix: "test",
 				Mqtt: mqtt.Configuration{
-					Enabled: true,
-					Host:    "", // Empty host prevents connection attempt
+					Enabled:     true,
+					Host:        "", // Empty host prevents connection attempt
+					TopicPrefix: "test",
 				},
 				Solace: solace.Configuration{
 					Enabled: false,
@@ -37,14 +37,14 @@ func TestNewPublisher(t *testing.T) {
 		{
 			name: "Solace enabled but no host - returns empty Solace publisher",
 			config: config.SolarControllerConfiguration{
-				TopicPrefix: "test",
 				Mqtt: mqtt.Configuration{
 					Enabled: false,
 				},
 				Solace: solace.Configuration{
-					Enabled: true,
-					Host:    "", // Empty host prevents connection attempt
-					VpnName: "default",
+					Enabled:     true,
+					Host:        "", // Empty host prevents connection attempt
+					VpnName:     "default",
+					TopicPrefix: "test",
 				},
 			},
 			wantErr: false,
@@ -72,20 +72,26 @@ func TestNewPublisher(t *testing.T) {
 			},
 		},
 		{
-			name: "Both enabled - returns error",
+			name: "Both MQTT and Solace enabled - returns MultiPublisher",
 			config: config.SolarControllerConfiguration{
-				TopicPrefix: "test",
 				Mqtt: mqtt.Configuration{
-					Enabled: true,
-					Host:    "",
+					Enabled:     true,
+					Host:        "", // Empty host prevents connection attempt
+					TopicPrefix: "test",
 				},
 				Solace: solace.Configuration{
-					Enabled: true,
-					Host:    "",
-					VpnName: "default",
+					Enabled:     true,
+					Host:        "", // Empty host prevents connection attempt
+					VpnName:     "default",
+					TopicPrefix: "test",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
+			check: func(t *testing.T, pub interface{}) {
+				if _, ok := pub.(*MultiPublisher); !ok {
+					t.Errorf("expected *MultiPublisher, got %T", pub)
+				}
+			},
 		},
 		{
 			name: "MQTT disabled, Solace disabled - returns no-op publisher",

--- a/internal/publishers/multi_publisher.go
+++ b/internal/publishers/multi_publisher.go
@@ -1,0 +1,38 @@
+package publishers
+
+import (
+	"github.com/lumberbarons/solar-controller/internal/controllers"
+	"github.com/sirupsen/logrus"
+)
+
+// MultiPublisher implements MessagePublisher by fanning out to multiple publishers.
+// It provides best-effort delivery: if one publisher fails, others continue to receive messages.
+type MultiPublisher struct {
+	publishers []controllers.MessagePublisher
+	logger     *logrus.Logger
+}
+
+// NewMultiPublisher creates a new MultiPublisher that fans out to all provided publishers.
+func NewMultiPublisher(publishers []controllers.MessagePublisher, logger *logrus.Logger) *MultiPublisher {
+	return &MultiPublisher{
+		publishers: publishers,
+		logger:     logger,
+	}
+}
+
+// Publish sends the message to all configured publishers.
+// Errors from individual publishers are logged but do not stop other publishers from receiving the message.
+func (m *MultiPublisher) Publish(topicSuffix, payload string) {
+	for _, publisher := range m.publishers {
+		// Each publisher handles its own error logging internally
+		// We just fan out the message
+		publisher.Publish(topicSuffix, payload)
+	}
+}
+
+// Close closes all configured publishers.
+func (m *MultiPublisher) Close() {
+	for _, publisher := range m.publishers {
+		publisher.Close()
+	}
+}

--- a/internal/publishers/multi_publisher_test.go
+++ b/internal/publishers/multi_publisher_test.go
@@ -1,0 +1,178 @@
+package publishers
+
+import (
+	"testing"
+
+	"github.com/lumberbarons/solar-controller/internal/controllers"
+	"github.com/sirupsen/logrus"
+)
+
+// MockPublisher is a test double for MessagePublisher
+type MockPublisher struct {
+	publishCalls []publishCall
+	closeCalled  bool
+}
+
+type publishCall struct {
+	topicSuffix string
+	payload     string
+}
+
+func (m *MockPublisher) Publish(topicSuffix, payload string) {
+	m.publishCalls = append(m.publishCalls, publishCall{
+		topicSuffix: topicSuffix,
+		payload:     payload,
+	})
+}
+
+func (m *MockPublisher) Close() {
+	m.closeCalled = true
+}
+
+// Ensure MockPublisher implements MessagePublisher
+var _ controllers.MessagePublisher = (*MockPublisher)(nil)
+
+func TestMultiPublisher_Publish_FansOutToAllPublishers(t *testing.T) {
+	// Arrange
+	mock1 := &MockPublisher{}
+	mock2 := &MockPublisher{}
+	mock3 := &MockPublisher{}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel) // Suppress logs during test
+
+	multiPublisher := NewMultiPublisher([]controllers.MessagePublisher{mock1, mock2, mock3}, logger)
+
+	// Act
+	multiPublisher.Publish("device-1/epever/battery-voltage", `{"value":12.5,"unit":"volts","timestamp":1234567890}`)
+
+	// Assert
+	if len(mock1.publishCalls) != 1 {
+		t.Errorf("Expected 1 publish call to mock1, got %d", len(mock1.publishCalls))
+	}
+	if len(mock2.publishCalls) != 1 {
+		t.Errorf("Expected 1 publish call to mock2, got %d", len(mock2.publishCalls))
+	}
+	if len(mock3.publishCalls) != 1 {
+		t.Errorf("Expected 1 publish call to mock3, got %d", len(mock3.publishCalls))
+	}
+
+	// Verify all received the same message
+	expectedTopic := "device-1/epever/battery-voltage"
+	expectedPayload := `{"value":12.5,"unit":"volts","timestamp":1234567890}`
+
+	if mock1.publishCalls[0].topicSuffix != expectedTopic {
+		t.Errorf("Mock1 received wrong topic: %s", mock1.publishCalls[0].topicSuffix)
+	}
+	if mock1.publishCalls[0].payload != expectedPayload {
+		t.Errorf("Mock1 received wrong payload: %s", mock1.publishCalls[0].payload)
+	}
+
+	if mock2.publishCalls[0].topicSuffix != expectedTopic {
+		t.Errorf("Mock2 received wrong topic: %s", mock2.publishCalls[0].topicSuffix)
+	}
+	if mock2.publishCalls[0].payload != expectedPayload {
+		t.Errorf("Mock2 received wrong payload: %s", mock2.publishCalls[0].payload)
+	}
+
+	if mock3.publishCalls[0].topicSuffix != expectedTopic {
+		t.Errorf("Mock3 received wrong topic: %s", mock3.publishCalls[0].topicSuffix)
+	}
+	if mock3.publishCalls[0].payload != expectedPayload {
+		t.Errorf("Mock3 received wrong payload: %s", mock3.publishCalls[0].payload)
+	}
+}
+
+func TestMultiPublisher_PublishMultipleTimes(t *testing.T) {
+	// Arrange
+	mock1 := &MockPublisher{}
+	mock2 := &MockPublisher{}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	multiPublisher := NewMultiPublisher([]controllers.MessagePublisher{mock1, mock2}, logger)
+
+	// Act - publish 3 different metrics
+	multiPublisher.Publish("device-1/epever/battery-voltage", `{"value":12.5}`)
+	multiPublisher.Publish("device-1/epever/battery-current", `{"value":5.2}`)
+	multiPublisher.Publish("device-1/epever/battery-soc", `{"value":85}`)
+
+	// Assert
+	if len(mock1.publishCalls) != 3 {
+		t.Errorf("Expected 3 publish calls to mock1, got %d", len(mock1.publishCalls))
+	}
+	if len(mock2.publishCalls) != 3 {
+		t.Errorf("Expected 3 publish calls to mock2, got %d", len(mock2.publishCalls))
+	}
+
+	// Verify order is preserved
+	if mock1.publishCalls[0].topicSuffix != "device-1/epever/battery-voltage" {
+		t.Errorf("Wrong order for mock1 call 0")
+	}
+	if mock1.publishCalls[1].topicSuffix != "device-1/epever/battery-current" {
+		t.Errorf("Wrong order for mock1 call 1")
+	}
+	if mock1.publishCalls[2].topicSuffix != "device-1/epever/battery-soc" {
+		t.Errorf("Wrong order for mock1 call 2")
+	}
+}
+
+func TestMultiPublisher_Close_ClosesAllPublishers(t *testing.T) {
+	// Arrange
+	mock1 := &MockPublisher{}
+	mock2 := &MockPublisher{}
+	mock3 := &MockPublisher{}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	multiPublisher := NewMultiPublisher([]controllers.MessagePublisher{mock1, mock2, mock3}, logger)
+
+	// Act
+	multiPublisher.Close()
+
+	// Assert
+	if !mock1.closeCalled {
+		t.Error("Expected mock1.Close() to be called")
+	}
+	if !mock2.closeCalled {
+		t.Error("Expected mock2.Close() to be called")
+	}
+	if !mock3.closeCalled {
+		t.Error("Expected mock3.Close() to be called")
+	}
+}
+
+func TestMultiPublisher_EmptyPublishers(_ *testing.T) {
+	// Arrange
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	multiPublisher := NewMultiPublisher([]controllers.MessagePublisher{}, logger)
+
+	// Act & Assert - should not panic
+	multiPublisher.Publish("device-1/epever/test", `{"value":1}`)
+	multiPublisher.Close()
+}
+
+func TestMultiPublisher_SinglePublisher(t *testing.T) {
+	// Arrange
+	mock := &MockPublisher{}
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	multiPublisher := NewMultiPublisher([]controllers.MessagePublisher{mock}, logger)
+
+	// Act
+	multiPublisher.Publish("device-1/epever/test", `{"value":1}`)
+	multiPublisher.Close()
+
+	// Assert
+	if len(mock.publishCalls) != 1 {
+		t.Errorf("Expected 1 publish call, got %d", len(mock.publishCalls))
+	}
+	if !mock.closeCalled {
+		t.Error("Expected Close() to be called")
+	}
+}

--- a/internal/remotewrite/configuration.go
+++ b/internal/remotewrite/configuration.go
@@ -23,6 +23,9 @@ type Configuration struct {
 	// Headers allows custom headers to be added to requests (optional)
 	// Example: X-Scope-OrgID for Cortex multi-tenancy
 	Headers map[string]string `yaml:"headers,omitempty"`
+
+	// TopicPrefix overrides global topicPrefix (optional)
+	TopicPrefix string `yaml:"topicPrefix,omitempty"`
 }
 
 // BasicAuthConfig holds HTTP Basic Authentication credentials.

--- a/internal/solace/publisher.go
+++ b/internal/solace/publisher.go
@@ -13,11 +13,12 @@ import (
 )
 
 type Configuration struct {
-	Enabled  bool   `yaml:"enabled"`
-	Host     string `yaml:"host"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	VpnName  string `yaml:"vpnName"`
+	Enabled     bool   `yaml:"enabled"`
+	Host        string `yaml:"host"`
+	Username    string `yaml:"username"`
+	Password    string `yaml:"password"`
+	VpnName     string `yaml:"vpnName"`
+	TopicPrefix string `yaml:"topicPrefix"` // Optional: overrides global topicPrefix
 }
 
 type Publisher struct {


### PR DESCRIPTION
## Summary

Removes the mutual exclusion constraint that previously limited the application to a single message publisher. Multiple publishers (MQTT, Solace, File, RemoteWrite) can now be enabled simultaneously, with metrics fanned out to all enabled destinations using best-effort delivery.

## Changes

- Add `MultiPublisher` wrapper that implements fan-out pattern to multiple publishers
- Move `topicPrefix` from global configuration to per-publisher configuration (MQTT, Solace, RemoteWrite)
- Remove `topicPrefix` from file publisher (writes full topic path directly)
- Remove configuration validation that prevented multiple publishers from being enabled
- Rename `mqttPublisher` field to generic `publisher` in controllers
- Update factory to create single publisher, or wrap multiple in `MultiPublisher`
- Update all tests to reflect multi-publisher support
- Update documentation with new configuration structure and multi-publisher behavior

## Testing

- All unit tests pass (`go test ./...`)
- Linters pass (`golangci-lint run`)
- Build succeeds (`make build-backend`)
- Added comprehensive tests for `MultiPublisher` fan-out behavior
- Updated config tests to validate multiple publishers can be enabled
- Updated file publisher tests to verify direct topic path writing

## Checklist

- [x] Tests added/updated
- [x] Linters pass (`golangci-lint run`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated (if needed)