### PR TITLE
chore: bump CI and build Go version to 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   NODE_VERSION: '22'
 
 jobs:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 golang:1.24-trixie AS go-builder
+FROM --platform=linux/arm64 golang:1.25-trixie AS go-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Several open dependabot PRs (#78 gin→prometheus, #80 gin, #94/#95 testcontainers) bump dependencies whose go.mod now requires `go >= 1.25.0`. CI pins `GO_VERSION: '1.24'` with `GOTOOLCHAIN=local`, so their Test and Lint jobs fail with:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

This bumps Go to 1.25 in the CI workflow, release workflow, and the ARM64 cross-build image (golangci-lint v2.5.0 already supports Go 1.25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)