### PR TITLE
docs: single-command gh issue bodies via stdin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,24 @@ filenames in inline code.
 - [ ] Verifiable completion criterion, as a checklist
 ```
 
+### Creating and editing issues in one command
+
+`gh` reads bodies from stdin via `--body-file -`, so never write a body to a temp file first — create or edit an issue with its full markdown body in a single command:
+
+```bash
+gh issue create --title "Title here" --label P2,task --body-file - <<'EOF'
+### Goal
+
+What and why.
+
+### Done when
+
+- [ ] Criterion
+EOF
+```
+
+The same pattern works for `gh issue edit <n> --body-file -` and `gh pr create --body-file -`.
+
 ### Workflow
 
 1. Find work: `gh issue list --state open`, pick the highest-priority issue with no open blockers


### PR DESCRIPTION
Follow-up to #135. Agents were writing issue bodies to temp files before calling `gh issue edit --body-file <file>` — two steps per issue. `gh` reads bodies from stdin with `--body-file -`, so CLAUDE.md now documents the heredoc pattern that makes issue create/edit a single command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)