### PR TITLE
feat: voltgo metrics conversion and Prometheus collector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240226150601-1dcf7310316a // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/internal/controllers/voltgo/interfaces.go
+++ b/internal/controllers/voltgo/interfaces.go
@@ -24,6 +24,16 @@ type BatteryClient interface {
 	Disconnect() error
 }
 
+// MetricsCollector defines the interface for collecting and exposing metrics.
+// This abstraction allows for testing without the Prometheus global registry.
+type MetricsCollector interface {
+	// IncrementFailures increments the collection failure counter.
+	IncrementFailures()
+
+	// SetMetrics updates all metrics based on the provided status.
+	SetMetrics(status *BatteryStatus)
+}
+
 // BatteryConnector defines the interface for establishing BLE connections
 // to voltgo batteries.
 type BatteryConnector interface {

--- a/internal/controllers/voltgo/metrics.go
+++ b/internal/controllers/voltgo/metrics.go
@@ -1,0 +1,129 @@
+package voltgo
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Metric represents a single metric with its value, unit, and timestamp
+type Metric struct {
+	Name      string
+	Value     any
+	Unit      string
+	Timestamp int64
+}
+
+// MetricPayload is the JSON structure published for each metric
+type MetricPayload struct {
+	Value     any    `json:"value"`
+	Unit      string `json:"unit"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// ToJSON converts a Metric to its JSON representation
+func (m *Metric) ToJSON() (string, error) {
+	payload := MetricPayload{
+		Value:     m.Value,
+		Unit:      m.Unit,
+		Timestamp: m.Timestamp,
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal metric payload: %w", err)
+	}
+
+	return string(b), nil
+}
+
+// ConvertStatusToMetrics converts a BatteryStatus into individual metrics.
+// Per-cell voltages are deliberately not converted - they are exposed via
+// Prometheus and the HTTP API only, to keep the published topic space bounded.
+func ConvertStatusToMetrics(status *BatteryStatus) []Metric {
+	if status == nil {
+		return []Metric{}
+	}
+
+	timestamp := status.Timestamp
+
+	return []Metric{
+		{
+			Name:      "battery-voltage",
+			Value:     status.Voltage,
+			Unit:      "volts",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "battery-current",
+			Value:     status.Current,
+			Unit:      "amperes",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "battery-power",
+			Value:     status.Voltage * status.Current,
+			Unit:      "watts",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "battery-soc",
+			Value:     status.SOC,
+			Unit:      "percent",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "battery-soh",
+			Value:     status.SOH,
+			Unit:      "percent",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "battery-temp",
+			Value:     status.Temperature,
+			Unit:      "celsius",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "cell-voltage-delta",
+			Value:     cellVoltageDelta(status.Cells),
+			Unit:      "volts",
+			Timestamp: timestamp,
+		},
+		{
+			Name:      "collection-time",
+			Value:     status.CollectionTime,
+			Unit:      "seconds",
+			Timestamp: timestamp,
+		},
+	}
+}
+
+// cellVoltageDelta returns the spread between the highest and lowest cell
+// voltage, or 0 when there are no cells.
+func cellVoltageDelta(cells []Cell) float64 {
+	if len(cells) == 0 {
+		return 0
+	}
+
+	minV, maxV := cells[0].Voltage, cells[0].Voltage
+	for _, cell := range cells[1:] {
+		if cell.Voltage < minV {
+			minV = cell.Voltage
+		}
+		if cell.Voltage > maxV {
+			maxV = cell.Voltage
+		}
+	}
+	return maxV - minV
+}
+
+// CreateCollectionFailureMetric creates a failure metric when collection fails
+func CreateCollectionFailureMetric() Metric {
+	return Metric{
+		Name:      "collection-failure",
+		Value:     1,
+		Unit:      "count",
+		Timestamp: time.Now().Unix(),
+	}
+}

--- a/internal/controllers/voltgo/metrics_test.go
+++ b/internal/controllers/voltgo/metrics_test.go
@@ -1,0 +1,135 @@
+package voltgo
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestConvertStatusToMetrics(t *testing.T) {
+	t.Run("converts all metrics with correct names, units, and values", func(t *testing.T) {
+		status := &BatteryStatus{
+			Timestamp:      1699000000,
+			CollectionTime: 0.42,
+			Voltage:        13.28,
+			Current:        -2.5,
+			SOC:            87,
+			SOH:            100,
+			Temperature:    21.5,
+			Temperatures:   []int{21, 22},
+			CellCount:      4,
+			Cells: []Cell{
+				{Index: 0, Voltage: 3.321},
+				{Index: 1, Voltage: 3.318},
+				{Index: 2, Voltage: 3.322},
+				{Index: 3, Voltage: 3.319},
+			},
+		}
+
+		metrics := ConvertStatusToMetrics(status)
+
+		want := []struct {
+			name  string
+			value any
+			unit  string
+		}{
+			{"battery-voltage", 13.28, "volts"},
+			{"battery-current", -2.5, "amperes"},
+			{"battery-power", status.Voltage * status.Current, "watts"},
+			{"battery-soc", 87, "percent"},
+			{"battery-soh", 100, "percent"},
+			{"battery-temp", 21.5, "celsius"},
+			{"cell-voltage-delta", status.Cells[2].Voltage - status.Cells[1].Voltage, "volts"},
+			{"collection-time", 0.42, "seconds"},
+		}
+
+		if len(metrics) != len(want) {
+			t.Fatalf("metrics length = %d, want %d", len(metrics), len(want))
+		}
+
+		for i, w := range want {
+			m := metrics[i]
+			if m.Name != w.name {
+				t.Errorf("metrics[%d].Name = %s, want %s", i, m.Name, w.name)
+			}
+			if m.Unit != w.unit {
+				t.Errorf("%s Unit = %s, want %s", w.name, m.Unit, w.unit)
+			}
+			if m.Value != w.value {
+				t.Errorf("%s Value = %v, want %v", w.name, m.Value, w.value)
+			}
+			if m.Timestamp != status.Timestamp {
+				t.Errorf("%s Timestamp = %d, want %d", w.name, m.Timestamp, status.Timestamp)
+			}
+		}
+	})
+
+	t.Run("nil status returns empty slice", func(t *testing.T) {
+		metrics := ConvertStatusToMetrics(nil)
+		if len(metrics) != 0 {
+			t.Errorf("metrics length = %d, want 0", len(metrics))
+		}
+	})
+
+	t.Run("no cells yields zero voltage delta", func(t *testing.T) {
+		metrics := ConvertStatusToMetrics(&BatteryStatus{})
+
+		for _, m := range metrics {
+			if m.Name == "cell-voltage-delta" {
+				if m.Value != 0.0 {
+					t.Errorf("cell-voltage-delta = %v, want 0", m.Value)
+				}
+				return
+			}
+		}
+		t.Fatal("cell-voltage-delta metric not found")
+	})
+}
+
+func TestMetricToJSON(t *testing.T) {
+	metric := Metric{
+		Name:      "battery-voltage",
+		Value:     13.28,
+		Unit:      "volts",
+		Timestamp: 1699000000,
+	}
+
+	jsonStr, err := metric.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &payload); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if payload["value"] != 13.28 {
+		t.Errorf("value = %v, want 13.28", payload["value"])
+	}
+	if payload["unit"] != "volts" {
+		t.Errorf("unit = %v, want volts", payload["unit"])
+	}
+	if payload["timestamp"] != float64(1699000000) {
+		t.Errorf("timestamp = %v, want 1699000000", payload["timestamp"])
+	}
+}
+
+func TestCreateCollectionFailureMetric(t *testing.T) {
+	before := time.Now().Unix()
+	metric := CreateCollectionFailureMetric()
+	after := time.Now().Unix()
+
+	if metric.Name != "collection-failure" {
+		t.Errorf("Name = %s, want collection-failure", metric.Name)
+	}
+	if metric.Value != 1 {
+		t.Errorf("Value = %v, want 1", metric.Value)
+	}
+	if metric.Unit != "count" {
+		t.Errorf("Unit = %s, want count", metric.Unit)
+	}
+	if metric.Timestamp < before || metric.Timestamp > after {
+		t.Errorf("Timestamp = %d, want between %d and %d", metric.Timestamp, before, after)
+	}
+}

--- a/internal/controllers/voltgo/prometheus.go
+++ b/internal/controllers/voltgo/prometheus.go
@@ -1,0 +1,108 @@
+package voltgo
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type PrometheusCollector struct {
+	failures prometheus.Counter
+
+	batteryVoltage prometheus.Gauge
+	batteryCurrent prometheus.Gauge
+	batteryPower   prometheus.Gauge
+	batterySoc     prometheus.Gauge
+	batterySoh     prometheus.Gauge
+	batteryTemp    prometheus.Gauge
+
+	cellVoltageDelta prometheus.Gauge
+	cellVoltage      *prometheus.GaugeVec
+}
+
+func NewPrometheusCollector() *PrometheusCollector {
+	endpoint := &PrometheusCollector{
+		failures: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "read_failures",
+			Help:      "Number of errors while reading from the voltgo battery.",
+		}),
+	}
+
+	// Initialize all metrics immediately to avoid race conditions
+	endpoint.initializeMetrics()
+
+	return endpoint
+}
+
+func (v *PrometheusCollector) IncrementFailures() {
+	v.failures.Inc()
+}
+
+func (v *PrometheusCollector) initializeMetrics() {
+	v.batteryVoltage = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "battery_voltage",
+		Help:      "Battery pack voltage (V).",
+	})
+
+	v.batteryCurrent = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "battery_current",
+		Help:      "Battery pack current (A), positive when charging, negative when discharging.",
+	})
+
+	v.batteryPower = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "battery_power",
+		Help:      "Battery pack power (W), derived from voltage and current.",
+	})
+
+	v.batterySoc = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "battery_soc",
+		Help:      "Battery state of charge (%).",
+	})
+
+	v.batterySoh = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "battery_soh",
+		Help:      "Battery state of health (%).",
+	})
+
+	v.batteryTemp = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "battery_temp",
+		Help:      "Battery temperature (C).",
+	})
+
+	v.cellVoltageDelta = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "cell_voltage_delta",
+		Help:      "Spread between the highest and lowest cell voltage (V).",
+	})
+
+	v.cellVoltage = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "cell_voltage",
+			Help:      "Individual cell voltage (V).",
+		},
+		[]string{"cell"},
+	)
+}
+
+func (v *PrometheusCollector) SetMetrics(status *BatteryStatus) {
+	v.batteryVoltage.Set(status.Voltage)
+	v.batteryCurrent.Set(status.Current)
+	v.batteryPower.Set(status.Voltage * status.Current)
+	v.batterySoc.Set(float64(status.SOC))
+	v.batterySoh.Set(float64(status.SOH))
+	v.batteryTemp.Set(status.Temperature)
+
+	v.cellVoltageDelta.Set(cellVoltageDelta(status.Cells))
+	for _, cell := range status.Cells {
+		v.cellVoltage.WithLabelValues(strconv.Itoa(cell.Index)).Set(cell.Voltage)
+	}
+}

--- a/internal/controllers/voltgo/prometheus_test.go
+++ b/internal/controllers/voltgo/prometheus_test.go
@@ -1,0 +1,67 @@
+package voltgo
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// Verify PrometheusCollector implements MetricsCollector
+var _ MetricsCollector = (*PrometheusCollector)(nil)
+
+// The collector registers with the global Prometheus registry via promauto,
+// so it can only be created once per test binary.
+func TestPrometheusCollector(t *testing.T) {
+	collector := NewPrometheusCollector()
+
+	t.Run("SetMetrics updates all gauges", func(t *testing.T) {
+		status := &BatteryStatus{
+			Voltage:     13.28,
+			Current:     -2.5,
+			SOC:         87,
+			SOH:         100,
+			Temperature: 21.5,
+			CellCount:   4,
+			Cells: []Cell{
+				{Index: 0, Voltage: 3.321},
+				{Index: 1, Voltage: 3.318},
+				{Index: 2, Voltage: 3.322},
+				{Index: 3, Voltage: 3.319},
+			},
+		}
+
+		collector.SetMetrics(status)
+
+		checks := []struct {
+			name string
+			got  float64
+			want float64
+		}{
+			{"battery_voltage", testutil.ToFloat64(collector.batteryVoltage), 13.28},
+			{"battery_current", testutil.ToFloat64(collector.batteryCurrent), -2.5},
+			{"battery_power", testutil.ToFloat64(collector.batteryPower), status.Voltage * status.Current},
+			{"battery_soc", testutil.ToFloat64(collector.batterySoc), 87},
+			{"battery_soh", testutil.ToFloat64(collector.batterySoh), 100},
+			{"battery_temp", testutil.ToFloat64(collector.batteryTemp), 21.5},
+			{"cell_voltage_delta", testutil.ToFloat64(collector.cellVoltageDelta), status.Cells[2].Voltage - status.Cells[1].Voltage},
+		}
+
+		for _, c := range checks {
+			if c.got != c.want {
+				t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+			}
+		}
+
+		if got := testutil.ToFloat64(collector.cellVoltage.WithLabelValues("2")); got != 3.322 {
+			t.Errorf("cell_voltage{cell=\"2\"} = %v, want 3.322", got)
+		}
+	})
+
+	t.Run("IncrementFailures increments the counter", func(t *testing.T) {
+		before := testutil.ToFloat64(collector.failures)
+		collector.IncrementFailures()
+		if got := testutil.ToFloat64(collector.failures); got != before+1 {
+			t.Errorf("read_failures = %v, want %v", got, before+1)
+		}
+	})
+}

--- a/internal/controllers/voltgo/voltgo.go
+++ b/internal/controllers/voltgo/voltgo.go
@@ -4,7 +4,11 @@ import (
 	"time"
 )
 
-const defaultConnectTimeout = 30 * time.Second
+const (
+	namespace = "voltgo"
+
+	defaultConnectTimeout = 30 * time.Second
+)
 
 type Configuration struct {
 	Enabled       bool   `yaml:"enabled"`


### PR DESCRIPTION
Fixes #121

Second slice of voltgo BLE battery support (epic #137), building on the collector from #120:

- `metrics.go`: `ConvertStatusToMetrics` maps `BatteryStatus` to kebab-case metrics in the epever `{value,unit,timestamp}` payload format: `battery-voltage` (volts), `battery-current` (amperes, signed +charge/-discharge), `battery-power` (watts, derived V*I), `battery-soc`/`battery-soh` (percent), `battery-temp` (celsius), `cell-voltage-delta` (volts, max-min spread), `collection-time` (seconds), plus `collection-failure` (count) for failed cycles
- Per-cell voltages are **not** published as topics — they're exposed via a Prometheus `GaugeVec` with a `cell` label (and later via the HTTP API), keeping the topic space and remote-write metric names bounded
- `prometheus.go`: `PrometheusCollector` under the `voltgo` namespace with gauges for all of the above, a `read_failures` counter, and the `cell_voltage` GaugeVec
- `MetricsCollector` interface added to `interfaces.go` so #122's controller orchestration can be tested without the global Prometheus registry
- Unit tests cover conversion (names/units/values/timestamps, delta computation, nil status, failure metric, JSON payload shape) and gauge values after `SetMetrics` via `client_golang`'s testutil

🤖 Generated with [Claude Code](https://claude.com/claude-code)