### PR TITLE
feat: voltgo controller orchestration and HTTP endpoints

### DIFF
--- a/internal/controllers/voltgo/mocks_test.go
+++ b/internal/controllers/voltgo/mocks_test.go
@@ -72,6 +72,42 @@ func (m *MockBatteryClient) Disconnect() error {
 	return nil
 }
 
+// MockMetricsCollector is a mock implementation of the MetricsCollector interface for testing.
+type MockMetricsCollector struct {
+	mu sync.RWMutex
+
+	// Function fields that can be set to customize behavior in tests
+	IncrementFailuresFunc func()
+	SetMetricsFunc        func(status *BatteryStatus)
+
+	// Call tracking
+	FailuresCount   int
+	SetMetricsCalls []*BatteryStatus
+}
+
+// Verify MockMetricsCollector implements MetricsCollector
+var _ MetricsCollector = (*MockMetricsCollector)(nil)
+
+func (m *MockMetricsCollector) IncrementFailures() {
+	m.mu.Lock()
+	m.FailuresCount++
+	m.mu.Unlock()
+
+	if m.IncrementFailuresFunc != nil {
+		m.IncrementFailuresFunc()
+	}
+}
+
+func (m *MockMetricsCollector) SetMetrics(status *BatteryStatus) {
+	m.mu.Lock()
+	m.SetMetricsCalls = append(m.SetMetricsCalls, status)
+	m.mu.Unlock()
+
+	if m.SetMetricsFunc != nil {
+		m.SetMetricsFunc(status)
+	}
+}
+
 // MockBatteryConnector is a mock implementation of the BatteryConnector interface for testing.
 type MockBatteryConnector struct {
 	mu sync.RWMutex

--- a/internal/controllers/voltgo/voltgo.go
+++ b/internal/controllers/voltgo/voltgo.go
@@ -1,13 +1,26 @@
 package voltgo
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-co-op/gocron"
+	"github.com/lumberbarons/solar-controller/internal/publish"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
 	namespace = "voltgo"
 
 	defaultConnectTimeout = 30 * time.Second
+
+	// collectTimeout bounds a full collection cycle: a BLE connect
+	// (default 30s) plus the status reads.
+	collectTimeout = 60 * time.Second
 )
 
 type Configuration struct {
@@ -40,4 +53,258 @@ func (c *Configuration) GetConnectTimeout() time.Duration {
 		return defaultConnectTimeout
 	}
 	return timeout
+}
+
+type Controller struct {
+	collector           *Collector
+	publisher           publish.MessagePublisher
+	prometheusCollector MetricsCollector
+	scheduler           *gocron.Scheduler
+	deviceID            string
+	lastStatus          *BatteryStatus
+	lastInfo            *BatteryInfo
+	lastStatusMutex     sync.RWMutex
+	collectInProgress   bool
+	collectMutex        sync.Mutex
+}
+
+// NewController creates a new voltgo controller with dependency injection for testing.
+// For production use, call NewControllerFromConfig instead.
+func NewController(
+	collector *Collector,
+	publisher publish.MessagePublisher,
+	prometheusCollector MetricsCollector,
+	deviceID string,
+	publishPeriod int,
+) (*Controller, error) {
+	if collector == nil {
+		return &Controller{}, nil
+	}
+
+	// Default device ID if not provided
+	if deviceID == "" {
+		deviceID = "controller-1"
+	}
+
+	s := gocron.NewScheduler(time.UTC)
+
+	controller := &Controller{
+		collector:           collector,
+		publisher:           publisher,
+		prometheusCollector: prometheusCollector,
+		deviceID:            deviceID,
+		scheduler:           s,
+	}
+
+	_, err := s.Every(publishPeriod).Seconds().Do(controller.collectAndPublish)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start voltgo publisher %w", err)
+	}
+
+	s.StartAsync()
+
+	// Run initial collection immediately
+	go controller.collectAndPublish()
+
+	return controller, nil
+}
+
+// newControllerForTest creates a Controller without starting the scheduler or background goroutine.
+// This allows tests to call collectAndPublish synchronously without racing.
+func newControllerForTest(
+	collector *Collector,
+	publisher publish.MessagePublisher,
+	prometheusCollector MetricsCollector,
+	deviceID string,
+) *Controller {
+	if deviceID == "" {
+		deviceID = "controller-1"
+	}
+	return &Controller{
+		collector:           collector,
+		publisher:           publisher,
+		prometheusCollector: prometheusCollector,
+		deviceID:            deviceID,
+	}
+}
+
+// NewControllerFromConfig creates a new voltgo controller from configuration.
+// This is the production entry point that creates all concrete dependencies.
+func NewControllerFromConfig(config Configuration, publisher publish.MessagePublisher, deviceID string) (*Controller, error) {
+	if !config.Enabled {
+		log.Info("voltgo disabled via configuration")
+		return &Controller{}, nil
+	}
+
+	if config.Address == "" {
+		log.Warn("voltgo enabled but no battery address provided")
+		return &Controller{}, nil
+	}
+
+	connector, err := NewBLEConnector()
+	if err != nil {
+		return nil, err
+	}
+
+	collector := NewCollector(connector, config.Address, config.GetConnectTimeout())
+	prometheusCollector := NewPrometheusCollector()
+
+	log.Infof("voltgo battery configured at %s", config.Address)
+
+	return NewController(
+		collector,
+		publisher,
+		prometheusCollector,
+		deviceID,
+		config.PublishPeriod,
+	)
+}
+
+func (v *Controller) collectAndPublish() {
+	// Check if a collection is already in progress
+	v.collectMutex.Lock()
+	if v.collectInProgress {
+		log.Warn("collection already in progress for voltgo controller, skipping this collection cycle")
+		v.collectMutex.Unlock()
+		return
+	}
+	v.collectInProgress = true
+	v.collectMutex.Unlock()
+
+	// Ensure we clear the flag when done
+	defer func() {
+		v.collectMutex.Lock()
+		v.collectInProgress = false
+		v.collectMutex.Unlock()
+	}()
+
+	log.Debug("collecting and publishing metrics for voltgo controller")
+
+	ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
+	defer cancel()
+
+	status, err := v.collector.GetStatus(ctx)
+	if err != nil {
+		log.Errorf("failed to collect metrics from voltgo battery: %s", err)
+		v.prometheusCollector.IncrementFailures()
+
+		// Publish failure metric to message broker
+		failureMetric := CreateCollectionFailureMetric()
+		payload, err := failureMetric.ToJSON()
+		if err != nil {
+			log.Errorf("failed to marshal failure metric: %s", err)
+			return
+		}
+
+		topicSuffix := fmt.Sprintf("%s/%s/%s", v.deviceID, namespace, failureMetric.Name)
+		v.publisher.Publish(topicSuffix, payload)
+		log.Debugf("published failure metric to %s", topicSuffix)
+
+		return
+	}
+
+	v.lastStatusMutex.Lock()
+	v.lastStatus = status
+	v.lastStatusMutex.Unlock()
+
+	v.prometheusCollector.SetMetrics(status)
+
+	// Fetch static battery info once, now that a connection is up
+	v.fetchInfoOnce(ctx)
+
+	// Convert status to individual metrics
+	metrics := ConvertStatusToMetrics(status)
+
+	// Publish each metric individually
+	for _, metric := range metrics {
+		payload, err := metric.ToJSON()
+		if err != nil {
+			log.Errorf("failed to marshal metric %s for publishing: %s", metric.Name, err)
+			continue
+		}
+
+		// Topic format: {deviceId}/voltgo/{metric-name}
+		topicSuffix := fmt.Sprintf("%s/%s/%s", v.deviceID, namespace, metric.Name)
+		v.publisher.Publish(topicSuffix, payload)
+
+		log.Debugf("published metric %s to %s", metric.Name, topicSuffix)
+	}
+
+	log.Debug("collection done for voltgo controller")
+}
+
+// fetchInfoOnce caches static battery info on the first successful collection
+// cycle. Failures are logged but never fail the cycle - the next cycle retries.
+func (v *Controller) fetchInfoOnce(ctx context.Context) {
+	v.lastStatusMutex.RLock()
+	cached := v.lastInfo != nil
+	v.lastStatusMutex.RUnlock()
+	if cached {
+		return
+	}
+
+	info, err := v.collector.GetInfo(ctx)
+	if err != nil {
+		log.Warnf("failed to read voltgo battery info: %s", err)
+		return
+	}
+
+	v.lastStatusMutex.Lock()
+	v.lastInfo = info
+	v.lastStatusMutex.Unlock()
+	log.Debugf("cached voltgo battery info: %s %.1fV %.0fAh", info.Chemistry, info.NominalVoltage, info.CapacityAh)
+}
+
+func (v *Controller) MetricsGet() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		v.lastStatusMutex.RLock()
+		status := v.lastStatus
+		v.lastStatusMutex.RUnlock()
+
+		if status == nil {
+			c.JSON(http.StatusNoContent, gin.H{})
+			return
+		}
+		c.JSON(http.StatusOK, status)
+	}
+}
+
+func (v *Controller) InfoGet() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		v.lastStatusMutex.RLock()
+		info := v.lastInfo
+		v.lastStatusMutex.RUnlock()
+
+		if info == nil {
+			c.JSON(http.StatusNoContent, gin.H{})
+			return
+		}
+		c.JSON(http.StatusOK, info)
+	}
+}
+
+func (v *Controller) RegisterEndpoints(r *gin.Engine) {
+	if v.collector == nil {
+		return
+	}
+
+	prefix := fmt.Sprintf("/api/%s", namespace)
+
+	r.GET(fmt.Sprintf("%s/metrics", prefix), v.MetricsGet())
+	r.GET(fmt.Sprintf("%s/info", prefix), v.InfoGet())
+}
+
+func (v *Controller) Enabled() bool {
+	return v.collector != nil
+}
+
+func (v *Controller) Close() error {
+	if v.scheduler != nil {
+		v.scheduler.Stop()
+		log.Debug("voltgo scheduler stopped")
+	}
+	if v.collector != nil {
+		return v.collector.Close()
+	}
+	return nil
 }

--- a/internal/controllers/voltgo/voltgo_test.go
+++ b/internal/controllers/voltgo/voltgo_test.go
@@ -1,0 +1,367 @@
+package voltgo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lumberbarons/solar-controller/internal/testutil"
+	"github.com/lumberbarons/voltgo/battery"
+)
+
+func newWorkingCollector() (*Collector, *MockBatteryClient, *MockBatteryConnector) {
+	mockBattery := &MockBatteryClient{
+		GetStatusFunc: func(_ context.Context) (*battery.Status, error) {
+			return testBatteryStatus(), nil
+		},
+		GetInfoFunc: func(_ context.Context) (*battery.Info, error) {
+			return &battery.Info{
+				Chemistry:      "LiFePO4",
+				NominalVoltage: 12.8,
+				CapacityAh:     100,
+				DeviceStrings:  []string{"VOLTGO-100"},
+			}, nil
+		},
+	}
+	mockConnector := &MockBatteryConnector{
+		ConnectFunc: func(_ context.Context, _ string) (BatteryClient, error) {
+			return mockBattery, nil
+		},
+	}
+	return NewCollector(mockConnector, "AA:BB:CC:DD:EE:FF", 10*time.Second), mockBattery, mockConnector
+}
+
+func newFailingCollector() *Collector {
+	mockConnector := &MockBatteryConnector{
+		ConnectFunc: func(_ context.Context, _ string) (BatteryClient, error) {
+			return nil, errors.New("device not found")
+		},
+	}
+	return NewCollector(mockConnector, "AA:BB:CC:DD:EE:FF", 10*time.Second)
+}
+
+func TestController_CollectAndPublish(t *testing.T) {
+	t.Run("publishes failure metric when collection fails", func(t *testing.T) {
+		mockMetrics := &MockMetricsCollector{}
+		mockPublisher := &testutil.MockMessagePublisher{}
+
+		controller := newControllerForTest(newFailingCollector(), mockPublisher, mockMetrics, "test-device-1")
+		controller.collectAndPublish()
+
+		if mockMetrics.FailuresCount != 1 {
+			t.Errorf("Expected FailuresCount = 1, got %d", mockMetrics.FailuresCount)
+		}
+
+		if len(mockPublisher.PublishCalls) != 1 {
+			t.Fatalf("Expected 1 publish call, got %d", len(mockPublisher.PublishCalls))
+		}
+
+		call := mockPublisher.PublishCalls[0]
+		expectedTopicSuffix := "test-device-1/voltgo/collection-failure"
+		if call.TopicSuffix != expectedTopicSuffix {
+			t.Errorf("Expected topic suffix %q, got %q", expectedTopicSuffix, call.TopicSuffix)
+		}
+
+		var payload MetricPayload
+		if err := json.Unmarshal([]byte(call.Payload), &payload); err != nil {
+			t.Fatalf("Failed to unmarshal payload: %v", err)
+		}
+		if payload.Value != float64(1) {
+			t.Errorf("Expected failure metric value = 1, got %v", payload.Value)
+		}
+		if payload.Unit != "count" {
+			t.Errorf("Expected failure metric unit = 'count', got %q", payload.Unit)
+		}
+	})
+
+	t.Run("publishes normal metrics when collection succeeds", func(t *testing.T) {
+		collector, _, _ := newWorkingCollector()
+		mockMetrics := &MockMetricsCollector{}
+		mockPublisher := &testutil.MockMessagePublisher{}
+
+		controller := newControllerForTest(collector, mockPublisher, mockMetrics, "test-device-1")
+		controller.collectAndPublish()
+
+		if mockMetrics.FailuresCount != 0 {
+			t.Errorf("Expected FailuresCount = 0, got %d", mockMetrics.FailuresCount)
+		}
+
+		if len(mockMetrics.SetMetricsCalls) != 1 {
+			t.Errorf("Expected 1 SetMetrics call, got %d", len(mockMetrics.SetMetricsCalls))
+		}
+
+		if len(mockPublisher.PublishCalls) != 8 {
+			t.Fatalf("Expected 8 publish calls for normal metrics, got %d", len(mockPublisher.PublishCalls))
+		}
+
+		for _, call := range mockPublisher.PublishCalls {
+			if strings.HasSuffix(call.TopicSuffix, "collection-failure") {
+				t.Error("collection-failure metric should not be published on successful collection")
+			}
+		}
+
+		metricNames := []string{
+			"battery-voltage", "battery-current", "battery-power",
+			"battery-soc", "battery-soh", "battery-temp",
+			"cell-voltage-delta", "collection-time",
+		}
+		for _, expectedMetric := range metricNames {
+			found := false
+			expectedSuffix := "test-device-1/voltgo/" + expectedMetric
+			for _, call := range mockPublisher.PublishCalls {
+				if call.TopicSuffix == expectedSuffix {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Expected metric %q not found in publish calls", expectedMetric)
+			}
+		}
+
+		payloadChecks := []struct {
+			metric string
+			value  float64
+			unit   string
+		}{
+			{"battery-voltage", 13.28, "volts"},
+			{"battery-soc", 87, "percent"},
+			{"battery-current", -2.5, "amperes"},
+		}
+		for _, pc := range payloadChecks {
+			suffix := "test-device-1/voltgo/" + pc.metric
+			for _, call := range mockPublisher.PublishCalls {
+				if call.TopicSuffix == suffix {
+					var payload MetricPayload
+					if err := json.Unmarshal([]byte(call.Payload), &payload); err != nil {
+						t.Fatalf("Failed to unmarshal %s payload: %v", pc.metric, err)
+					}
+					if payload.Value != pc.value {
+						t.Errorf("%s: value = %v, want %v", pc.metric, payload.Value, pc.value)
+					}
+					if payload.Unit != pc.unit {
+						t.Errorf("%s: unit = %q, want %q", pc.metric, payload.Unit, pc.unit)
+					}
+					break
+				}
+			}
+		}
+
+		controller.lastStatusMutex.RLock()
+		lastStatus := controller.lastStatus
+		controller.lastStatusMutex.RUnlock()
+		if lastStatus == nil {
+			t.Error("lastStatus should be cached after successful collection")
+		}
+	})
+
+	t.Run("fetches battery info once and caches it", func(t *testing.T) {
+		collector, mockBattery, _ := newWorkingCollector()
+		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+
+		controller.collectAndPublish()
+		controller.collectAndPublish()
+
+		if mockBattery.GetInfoCalls != 1 {
+			t.Errorf("GetInfo calls = %d, want 1 (info should be cached after first fetch)", mockBattery.GetInfoCalls)
+		}
+
+		controller.lastStatusMutex.RLock()
+		info := controller.lastInfo
+		controller.lastStatusMutex.RUnlock()
+		if info == nil {
+			t.Fatal("lastInfo should be cached")
+		}
+		if info.Chemistry != "LiFePO4" {
+			t.Errorf("Chemistry = %s, want LiFePO4", info.Chemistry)
+		}
+	})
+
+	t.Run("info fetch failure does not fail the collection cycle", func(t *testing.T) {
+		collector, mockBattery, _ := newWorkingCollector()
+		mockBattery.GetInfoFunc = func(_ context.Context) (*battery.Info, error) {
+			return nil, errors.New("BLE read timeout")
+		}
+
+		mockMetrics := &MockMetricsCollector{}
+		mockPublisher := &testutil.MockMessagePublisher{}
+		controller := newControllerForTest(collector, mockPublisher, mockMetrics, "test-device-1")
+
+		controller.collectAndPublish()
+
+		if mockMetrics.FailuresCount != 0 {
+			t.Errorf("Expected FailuresCount = 0, got %d", mockMetrics.FailuresCount)
+		}
+		if len(mockPublisher.PublishCalls) != 8 {
+			t.Errorf("Expected 8 publish calls, got %d", len(mockPublisher.PublishCalls))
+		}
+
+		// Info fetch is retried on the next cycle after a failure
+		mockBattery.GetInfoFunc = func(_ context.Context) (*battery.Info, error) {
+			return &battery.Info{Chemistry: "LiFePO4"}, nil
+		}
+		controller.collectAndPublish()
+
+		controller.lastStatusMutex.RLock()
+		info := controller.lastInfo
+		controller.lastStatusMutex.RUnlock()
+		if info == nil {
+			t.Error("lastInfo should be cached after retry")
+		}
+	})
+}
+
+func TestController_Endpoints(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newRouter := func(controller *Controller) *gin.Engine {
+		router := gin.New()
+		controller.RegisterEndpoints(router)
+		return router
+	}
+
+	t.Run("metrics and info return 204 before first collection", func(t *testing.T) {
+		collector, _, _ := newWorkingCollector()
+		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		router := newRouter(controller)
+
+		for _, path := range []string{"/api/voltgo/metrics", "/api/voltgo/info"} {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusNoContent {
+				t.Errorf("GET %s status = %d, want %d", path, w.Code, http.StatusNoContent)
+			}
+		}
+	})
+
+	t.Run("metrics returns last status including cells", func(t *testing.T) {
+		collector, _, _ := newWorkingCollector()
+		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller.collectAndPublish()
+		router := newRouter(controller)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/voltgo/metrics", nil)
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /api/voltgo/metrics status = %d, want %d", w.Code, http.StatusOK)
+		}
+
+		var status BatteryStatus
+		if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if status.Voltage != 13.28 {
+			t.Errorf("voltage = %v, want 13.28", status.Voltage)
+		}
+		if len(status.Cells) != 4 {
+			t.Errorf("cells length = %d, want 4", len(status.Cells))
+		}
+	})
+
+	t.Run("info returns cached battery info", func(t *testing.T) {
+		collector, _, _ := newWorkingCollector()
+		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller.collectAndPublish()
+		router := newRouter(controller)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/voltgo/info", nil)
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /api/voltgo/info status = %d, want %d", w.Code, http.StatusOK)
+		}
+
+		var info BatteryInfo
+		if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if info.Chemistry != "LiFePO4" {
+			t.Errorf("chemistry = %s, want LiFePO4", info.Chemistry)
+		}
+		if info.CapacityAh != 100 {
+			t.Errorf("capacityAh = %v, want 100", info.CapacityAh)
+		}
+	})
+
+	t.Run("disabled controller registers no endpoints", func(t *testing.T) {
+		controller := &Controller{}
+		router := newRouter(controller)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/voltgo/metrics", nil)
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("GET /api/voltgo/metrics on disabled controller status = %d, want %d", w.Code, http.StatusNotFound)
+		}
+	})
+}
+
+func TestController_Enabled(t *testing.T) {
+	disabled := &Controller{}
+	if disabled.Enabled() {
+		t.Error("empty controller should not be enabled")
+	}
+
+	collector, _, _ := newWorkingCollector()
+	enabled := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+	if !enabled.Enabled() {
+		t.Error("controller with a collector should be enabled")
+	}
+}
+
+func TestController_Close(t *testing.T) {
+	t.Run("disabled controller close is a no-op", func(t *testing.T) {
+		controller := &Controller{}
+		if err := controller.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	t.Run("close disconnects battery and releases adapter", func(t *testing.T) {
+		collector, mockBattery, mockConnector := newWorkingCollector()
+		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller.collectAndPublish()
+
+		if err := controller.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		if mockBattery.DisconnectCalls != 1 {
+			t.Errorf("Disconnect calls = %d, want 1", mockBattery.DisconnectCalls)
+		}
+		if mockConnector.CloseCalls != 1 {
+			t.Errorf("connector Close calls = %d, want 1", mockConnector.CloseCalls)
+		}
+	})
+}
+
+func TestNewControllerFromConfig_Disabled(t *testing.T) {
+	t.Run("disabled via configuration", func(t *testing.T) {
+		controller, err := NewControllerFromConfig(Configuration{Enabled: false}, &testutil.MockMessagePublisher{}, "test-device-1")
+		if err != nil {
+			t.Fatalf("NewControllerFromConfig() error = %v", err)
+		}
+		if controller.Enabled() {
+			t.Error("controller should be disabled")
+		}
+	})
+
+	t.Run("enabled but missing address", func(t *testing.T) {
+		controller, err := NewControllerFromConfig(Configuration{Enabled: true}, &testutil.MockMessagePublisher{}, "test-device-1")
+		if err != nil {
+			t.Fatalf("NewControllerFromConfig() error = %v", err)
+		}
+		if controller.Enabled() {
+			t.Error("controller should be disabled when address is missing")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #122

Third slice of voltgo BLE battery support (epic #137), building on #120/#121:

- `Controller` in `voltgo.go` implementing `controllers.SolarController`, mirroring the epever structure: gocron scheduler on `publishPeriod`, `collectAndPublish` with an overlap-prevention mutex, one message per metric published under `{deviceId}/voltgo/{metric-name}`, `collection-failure` published on failed cycles, and `lastStatus` cached under an `RWMutex`
- Static battery info (chemistry, nominal voltage, capacity, device strings) is fetched once after the first successful collection and cached; a failed info fetch is logged and retried on the next cycle without failing collection
- `RegisterEndpoints`: `GET /api/voltgo/metrics` (last status including per-cell voltages) and `GET /api/voltgo/info`, both returning 204 until data is available; no configurer since the BMS is read-only
- `NewControllerFromConfig` follows the epever convention: `enabled: false` or a missing address returns a disabled instance; the BLE adapter is only initialized when actually enabled
- `Close()` stops the scheduler, disconnects the battery, and releases the BLE adapter
- Tests via the `newControllerForTest` pattern: failure/success publish paths (topics, payloads, counts), info caching and retry, all endpoints, `Enabled`, `Close`, and disabled-config construction

App bootstrap and config wiring follow in #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)