### PR TITLE
chore: enforce backend coverage threshold in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,8 @@ jobs:
           name: site-build
           path: internal/static/build
 
-      - name: Run Go tests
-        run: go test -v -race -cover ./...
+      - name: Run Go tests with coverage gate
+        run: make test-coverage
 
   lint:
     name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ tmp/
 .claude/worktrees/
 
 # Test coverage profile
-coverage.out
+coverage*.out

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tmp/
 
 # Claude Code worktrees
 .claude/worktrees/
+
+# Test coverage profile
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test test-unit test-int test-all lint clean build-frontend build-backend build-linux-arm64-docker docker deploy
+.PHONY: help build test test-unit test-coverage test-int test-all lint clean build-frontend build-backend build-linux-arm64-docker docker deploy
 
 .DEFAULT_GOAL := help
 
@@ -9,6 +9,9 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD)
 
 # Build flags
 LDFLAGS := -X 'main.Version=$(VERSION)' -X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)'
+
+# Minimum total statement coverage (%) enforced by test-coverage
+COVERAGE_THRESHOLD ?= 65
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -44,6 +47,12 @@ test: test-unit ## Run unit tests (default)
 
 test-unit: ## Run unit tests only
 	go test -v -race ./...
+
+test-coverage: ## Run unit tests and fail if coverage is below COVERAGE_THRESHOLD
+	go test -v -race -coverprofile=coverage.out ./...
+	@go tool cover -func=coverage.out | tail -1 | awk -v threshold=$(COVERAGE_THRESHOLD) \
+		'{ gsub(/%/, "", $$3); printf "total statement coverage: %s%% (threshold: %s%%)\n", $$3, threshold; \
+		if ($$3 + 0 < threshold) { print "FAIL: coverage below threshold"; exit 1 } }'
 
 test-int: ## Run integration tests (requires Docker)
 	go test -v -race -tags=integration ./...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD)
 LDFLAGS := -X 'main.Version=$(VERSION)' -X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)'
 
 # Minimum total statement coverage (%) enforced by test-coverage
-COVERAGE_THRESHOLD ?= 65
+COVERAGE_THRESHOLD ?= 62
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -50,8 +50,9 @@ test-unit: ## Run unit tests only
 
 test-coverage: ## Run unit tests and fail if coverage is below COVERAGE_THRESHOLD
 	go test -v -race -coverprofile=coverage.out ./...
-	@go tool cover -func=coverage.out | tail -1 | awk -v threshold=$(COVERAGE_THRESHOLD) \
-		'{ gsub(/%/, "", $$3); printf "total statement coverage: %s%% (threshold: %s%%)\n", $$3, threshold; \
+	@grep -v '/internal/testutil/' coverage.out > coverage-filtered.out
+	@go tool cover -func=coverage-filtered.out | tail -1 | awk -v threshold=$(COVERAGE_THRESHOLD) \
+		'{ gsub(/%/, "", $$3); printf "total statement coverage (excluding testutil): %s%% (threshold: %s%%)\n", $$3, threshold; \
 		if ($$3 + 0 < threshold) { print "FAIL: coverage below threshold"; exit 1 } }'
 
 test-int: ## Run integration tests (requires Docker)


### PR DESCRIPTION
Fixes #142

Adds a coverage gate to CI so backend coverage can only ratchet up:

- `make test-coverage` runs the unit suite with `-coverprofile`, filters out `internal/testutil` (test scaffolding, not production code), and fails when total statement coverage is below `COVERAGE_THRESHOLD` (settable per-invocation, e.g. `make test-coverage COVERAGE_THRESHOLD=70`)
- The CI test job now runs `make test-coverage` instead of plain `go test -cover`
- Coverage profiles are gitignored

The threshold starts at 62. The true CI baseline is ~63%: the full Go toolchain counts no-test packages (`cmd/controller`, `internal/static`) at 0%, which local measurement missed due to a trimmed toolchain, and the total fluctuates slightly between runs, hence the headroom. Jumping straight to the 90% target would have turned CI red on every open PR — the gap is concentrated in packages whose I/O paths only run under integration tests (solace 34%, sns 40%, epever 53%, mqtt 74%). Raising the threshold to 90% as tests land is tracked in #143.

Note: Go's cover tooling measures statement coverage, which is the closest available proxy for line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)