### PR TITLE
chore: enforce per-package coverage floors and test controller wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Solar-controller is a Go-based service that collects metrics from solar power eq
 | `testdata/` | Modbus simulator configuration | Testing with simulated hardware |
 | `docs/` | Modbus register documentation, and `api-contract.json` | Understanding Epever register mappings, or changing an API field name |
 | `package/` | System packaging (deb, rpm) via nfpm | Changing release packaging |
+| `scripts/` | Coverage gate script and its per-package floors | Changing the coverage gate, or ratcheting a floor |
 | `Makefile` | Build, test, deploy orchestration | Modifying build targets or CI commands |
 | `Dockerfile` | Production container image | Changing container build or runtime |
 | `Dockerfile.build` | Cross-compilation build container | Changing ARM64 cross-build process |
@@ -106,7 +107,7 @@ publish artifacts that have not passed these gates:
 | Job | Enforces |
 |-----|----------|
 | `build-frontend` | `vite build` succeeds; publishes the `site-build` artifact the other jobs embed |
-| `test` | `go.mod`/`go.sum` are tidy, `go mod verify` passes, and `make test-coverage` clears the coverage gate |
+| `test` | `go.mod`/`go.sum` are tidy, `go mod verify` passes, and `make test-coverage` clears the coverage gate (see below) |
 | `lint` | `golangci-lint` (including `gosec`) over the Go tree |
 | `frontend` | ESLint, `tsc --noEmit`, and the vitest suite over `site/` |
 | `vulncheck` | `govulncheck` finds no reachable vulnerability, including in the standard library |
@@ -120,6 +121,23 @@ tag for readability.
 
 Release images are scanned with Trivy before the multi-arch manifest is pushed,
 and are published with an SBOM and build provenance attestation.
+
+#### The coverage gate
+
+`make test-coverage` enforces a per-package floor as well as the overall total,
+via `scripts/check-coverage.sh` reading `scripts/coverage-floors.txt`. A
+total-only gate hides weak packages behind well-tested ones —
+`internal/controllers/epever` holds most of the statements in the module, so a
+change that guts its coverage can still raise the total by adding a small,
+heavily tested package.
+
+The floors are a ratchet: each one is the coverage measured when it was
+recorded, rounded down. Raise a floor when you raise its coverage; never lower
+one to make a build pass. Every package in the coverage profile must appear in
+the file — an unlisted package fails the check, so adding a package forces a
+deliberate decision about its floor. Packages with no test files are listed with
+a floor of `0` so they stay visible as gaps rather than vanishing from the
+report. `COVERAGE_THRESHOLD` still sets the total.
 
 ### Using Make (Recommended)
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD)
 # Build flags
 LDFLAGS := -X 'main.Version=$(VERSION)' -X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)'
 
-# Minimum total statement coverage (%) enforced by test-coverage
+# Minimum total statement coverage (%) enforced by test-coverage. Per-package
+# floors live in scripts/coverage-floors.txt; both are checked.
 COVERAGE_THRESHOLD ?= 62
+COVERAGE_FLOORS ?= scripts/coverage-floors.txt
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -48,12 +50,9 @@ test: test-unit ## Run unit tests (default)
 test-unit: ## Run unit tests only
 	go test -v -race ./...
 
-test-coverage: ## Run unit tests and fail if coverage is below COVERAGE_THRESHOLD
+test-coverage: ## Run unit tests and fail if total or any package is below its floor
 	go test -v -race -coverprofile=coverage.out ./...
-	@grep -v '/internal/testutil/' coverage.out > coverage-filtered.out
-	@go tool cover -func=coverage-filtered.out | tail -1 | awk -v threshold=$(COVERAGE_THRESHOLD) \
-		'{ gsub(/%/, "", $$3); printf "total statement coverage (excluding testutil): %s%% (threshold: %s%%)\n", $$3, threshold; \
-		if ($$3 + 0 < threshold) { print "FAIL: coverage below threshold"; exit 1 } }'
+	@./scripts/check-coverage.sh coverage.out $(COVERAGE_FLOORS) $(COVERAGE_THRESHOLD)
 
 test-int: ## Run integration tests (requires Docker)
 	go test -v -race -tags=integration ./...

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,41 +36,40 @@ func init() {
 	})
 }
 
+// main handles only flag parsing and turning a startup failure into a non-zero
+// exit. Everything it does beyond that lives in functions that return errors, so
+// startup can be exercised by tests rather than terminating the process.
 func main() {
-	log.Infof("starting solar-controller version %s (commit: %s, built: %s)", Version, GitCommit, BuildTime)
-
 	flag.Parse()
 
-	controllerConfig := loadConfigFile()
+	if err := run(*configFilePath, *debugMode); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run starts the application and blocks until the HTTP server exits.
+func run(configPath string, debugFlag bool) error {
+	log.Infof("starting solar-controller version %s (commit: %s, built: %s)", Version, GitCommit, BuildTime)
+
+	controllerConfig, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
 
 	// Gin always runs in release mode: the debug flag controls application
 	// log verbosity only, not Gin's verbose route dumps and stack traces
 	gin.SetMode(gin.ReleaseMode)
 
-	// Command line flag takes precedence over config file
-	debugEnabled := *debugMode || controllerConfig.SolarController.Debug
-
-	if debugEnabled {
-		log.SetLevel(log.DebugLevel)
-		log.Debug("debug mode enabled")
-	} else {
-		log.SetLevel(log.InfoLevel)
-	}
+	configureLogging(resolveDebugMode(debugFlag, &controllerConfig))
 
 	publisher, err := publishers.NewPublisher(&controllerConfig.SolarController)
 	if err != nil {
-		log.Fatalf("failed to create publisher: %v", err)
+		return fmt.Errorf("failed to create publisher: %w", err)
 	}
 
-	versionInfo := app.VersionInfo{
-		Version:   Version,
-		BuildTime: BuildTime,
-		GitCommit: GitCommit,
-	}
-
-	application, err := app.NewApplication(&controllerConfig, publisher, versionInfo)
+	application, err := app.NewApplication(&controllerConfig, publisher, versionInfo())
 	if err != nil {
-		log.Fatalf("failed to create application: %v", err)
+		return fmt.Errorf("failed to create application: %w", err)
 	}
 	defer func() {
 		if err := application.Close(); err != nil {
@@ -93,24 +93,52 @@ func main() {
 	}()
 
 	if err := application.Run(); err != nil {
-		log.Errorf("failed to start server: %v", err)
+		return fmt.Errorf("failed to start server: %w", err)
+	}
+
+	return nil
+}
+
+// versionInfo returns the build metadata injected via ldflags.
+func versionInfo() app.VersionInfo {
+	return app.VersionInfo{
+		Version:   Version,
+		BuildTime: BuildTime,
+		GitCommit: GitCommit,
 	}
 }
 
-func loadConfigFile() config.Config {
-	if *configFilePath == "" {
-		log.Fatalf("Must specify config file path")
+// resolveDebugMode reports whether debug logging is on. The command line flag
+// takes precedence over the config file, so -debug can enable it for a config
+// that does not ask for it.
+func resolveDebugMode(debugFlag bool, cfg *config.Config) bool {
+	return debugFlag || cfg.SolarController.Debug
+}
+
+func configureLogging(debugEnabled bool) {
+	if debugEnabled {
+		log.SetLevel(log.DebugLevel)
+		log.Debug("debug mode enabled")
+		return
+	}
+	log.SetLevel(log.InfoLevel)
+}
+
+// loadConfig reads and parses the config file at path.
+func loadConfig(path string) (config.Config, error) {
+	if path == "" {
+		return config.Config{}, fmt.Errorf("must specify config file path")
 	}
 
-	configFile, err := os.ReadFile(*configFilePath)
+	configFile, err := os.ReadFile(path)
 	if err != nil {
-		log.Fatalf("failed to load configurer file: %v", err)
+		return config.Config{}, fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	cfg, err := config.Load(configFile)
 	if err != nil {
-		log.Fatalf("failed to load configuration: %v", err)
+		return config.Config{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	return cfg
+	return cfg, nil
 }

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lumberbarons/solar-controller/internal/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validConfig = `
+solarController:
+  httpPort: 9090
+  deviceId: controller-test
+  debug: false
+  epever:
+    enabled: true
+    serialPort: /dev/ttyXRUSB0
+    publishPeriod: 60
+`
+
+// writeConfig writes contents to a temp file and returns its path.
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("parses a valid config file", func(t *testing.T) {
+		cfg, err := loadConfig(writeConfig(t, validConfig))
+		require.NoError(t, err)
+
+		assert.Equal(t, 9090, cfg.SolarController.HTTPPort)
+		assert.Equal(t, "controller-test", cfg.SolarController.DeviceID)
+		assert.True(t, cfg.SolarController.Epever.Enabled)
+		assert.Equal(t, "/dev/ttyXRUSB0", cfg.SolarController.Epever.SerialPort)
+	})
+
+	t.Run("rejects an empty path instead of reading the working directory", func(t *testing.T) {
+		_, err := loadConfig("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must specify config file path")
+	})
+
+	t.Run("reports a missing file", func(t *testing.T) {
+		_, err := loadConfig(filepath.Join(t.TempDir(), "absent.yaml"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read config file")
+	})
+
+	t.Run("reports malformed YAML", func(t *testing.T) {
+		_, err := loadConfig(writeConfig(t, "solarController: [this is not a mapping"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load configuration")
+	})
+
+	t.Run("reports a config that parses but fails validation", func(t *testing.T) {
+		_, err := loadConfig(writeConfig(t, "solarController:\n  httpPort: 0\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load configuration")
+	})
+}
+
+func TestResolveDebugMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		debugFlag bool
+		fileDebug bool
+		want      bool
+	}{
+		{name: "off in both", debugFlag: false, fileDebug: false, want: false},
+		{name: "flag enables it for a config that does not ask", debugFlag: true, fileDebug: false, want: true},
+		{name: "config file alone enables it", debugFlag: false, fileDebug: true, want: true},
+		{name: "on in both", debugFlag: true, fileDebug: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				SolarController: config.SolarControllerConfiguration{Debug: tt.fileDebug},
+			}
+			assert.Equal(t, tt.want, resolveDebugMode(tt.debugFlag, &cfg))
+		})
+	}
+}
+
+func TestConfigureLogging(t *testing.T) {
+	original := log.GetLevel()
+	t.Cleanup(func() { log.SetLevel(original) })
+
+	configureLogging(true)
+	assert.Equal(t, log.DebugLevel, log.GetLevel())
+
+	configureLogging(false)
+	assert.Equal(t, log.InfoLevel, log.GetLevel())
+}
+
+func TestVersionInfo(t *testing.T) {
+	// Defaults stand in for the values ldflags injects at build time.
+	info := versionInfo()
+
+	assert.Equal(t, Version, info.Version)
+	assert.Equal(t, BuildTime, info.BuildTime)
+	assert.Equal(t, GitCommit, info.GitCommit)
+}
+
+func TestRunReturnsConfigErrorsRatherThanExiting(t *testing.T) {
+	// run must surface a startup failure as an error; main is the only place
+	// allowed to turn that into a process exit.
+	err := run("", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must specify config file path")
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,8 +27,31 @@ type Application struct {
 	router      *gin.Engine
 	server      *http.Server
 	publisher   publish.MessagePublisher
+	factories   []controllerFactory
 	controllers []controllers.SolarController
 	version     VersionInfo
+}
+
+// controllerFactory builds one hardware controller from configuration. Wiring
+// goes through this indirection so tests can assert which controllers get built
+// for a given config, and that each one receives the publisher, without needing
+// the real hardware: the production constructors open a serial port eagerly.
+type controllerFactory struct {
+	name  string
+	build func(cfg *config.SolarControllerConfiguration, publisher publish.MessagePublisher) (controllers.SolarController, error)
+}
+
+// defaultControllerFactories lists every controller the application can start.
+// Adding a controller means adding an entry here.
+func defaultControllerFactories() []controllerFactory {
+	return []controllerFactory{
+		{
+			name: "epever",
+			build: func(cfg *config.SolarControllerConfiguration, publisher publish.MessagePublisher) (controllers.SolarController, error) {
+				return epever.NewControllerFromConfig(cfg.Epever, publisher, cfg.DeviceID)
+			},
+		},
+	}
 }
 
 // VersionInfo holds version metadata about the application.
@@ -41,10 +64,15 @@ type VersionInfo struct {
 // NewApplication creates and initializes a new Application instance.
 // It sets up the HTTP router, initializes controllers, and registers endpoints.
 func NewApplication(cfg *config.Config, publisher publish.MessagePublisher, version VersionInfo) (*Application, error) {
+	return newApplication(cfg, publisher, version, defaultControllerFactories())
+}
+
+func newApplication(cfg *config.Config, publisher publish.MessagePublisher, version VersionInfo, factories []controllerFactory) (*Application, error) {
 	app := &Application{
 		config:    cfg,
 		publisher: publisher,
 		version:   version,
+		factories: factories,
 	}
 
 	// Initialize router
@@ -95,18 +123,22 @@ func authMiddleware(token string) gin.HandlerFunc {
 	}
 }
 
-// buildControllers initializes all solar equipment controllers based on configuration.
+// buildControllers initializes all solar equipment controllers based on
+// configuration. A controller that reports itself disabled — because config
+// turned it off, or because it is enabled but missing a required field — is
+// dropped rather than started.
 func (a *Application) buildControllers() error {
 	var ctrlList []controllers.SolarController
 
-	// Initialize Epever controller
-	epeverController, err := epever.NewControllerFromConfig(a.config.SolarController.Epever, a.publisher, a.config.SolarController.DeviceID)
-	if err != nil {
-		return fmt.Errorf("failed to create epever controller: %w", err)
-	}
+	for _, factory := range a.factories {
+		controller, err := factory.build(&a.config.SolarController, a.publisher)
+		if err != nil {
+			return fmt.Errorf("failed to create %s controller: %w", factory.name, err)
+		}
 
-	if epeverController.Enabled() {
-		ctrlList = append(ctrlList, epeverController)
+		if controller.Enabled() {
+			ctrlList = append(ctrlList, controller)
+		}
 	}
 
 	a.controllers = ctrlList

--- a/internal/app/wiring_test.go
+++ b/internal/app/wiring_test.go
@@ -1,0 +1,251 @@
+package app
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lumberbarons/solar-controller/internal/config"
+	"github.com/lumberbarons/solar-controller/internal/controllers"
+	"github.com/lumberbarons/solar-controller/internal/publish"
+	"github.com/lumberbarons/solar-controller/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeController records what it was handed and whether it was started, so the
+// wiring can be asserted without a serial port. The real epever constructor
+// opens the device eagerly, which is why buildControllers takes factories.
+type fakeController struct {
+	name       string
+	enabled    bool
+	publisher  publish.MessagePublisher
+	registered bool
+	closed     bool
+}
+
+func (f *fakeController) RegisterEndpoints(r *gin.Engine) {
+	f.registered = true
+	r.GET("/api/"+f.name+"/metrics", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"controller": f.name})
+	})
+}
+
+func (f *fakeController) Enabled() bool { return f.enabled }
+
+func (f *fakeController) Close() error {
+	f.closed = true
+	return nil
+}
+
+// newFakeFactory returns a factory that builds fake, recording the publisher it
+// was given.
+func newFakeFactory(fake *fakeController) controllerFactory {
+	return controllerFactory{
+		name: fake.name,
+		build: func(_ *config.SolarControllerConfiguration, publisher publish.MessagePublisher) (controllers.SolarController, error) {
+			fake.publisher = publisher
+			return fake, nil
+		},
+	}
+}
+
+func minimalConfig() *config.Config {
+	return &config.Config{
+		SolarController: config.SolarControllerConfiguration{HTTPPort: 8080},
+	}
+}
+
+func TestBuildControllers_BuiltSetMatchesConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name     string
+		fakes    []*fakeController
+		expected []string
+	}{
+		{
+			name:     "no controllers configured",
+			fakes:    nil,
+			expected: nil,
+		},
+		{
+			name:     "an enabled controller is started",
+			fakes:    []*fakeController{{name: "epever", enabled: true}},
+			expected: []string{"epever"},
+		},
+		{
+			name:     "a disabled controller is not started",
+			fakes:    []*fakeController{{name: "epever", enabled: false}},
+			expected: nil,
+		},
+		{
+			// A controller that is enabled in config but missing a required
+			// field returns an empty, disabled instance rather than an error.
+			name:     "an enabled but misconfigured controller is not started",
+			fakes:    []*fakeController{{name: "epever", enabled: false}},
+			expected: nil,
+		},
+		{
+			name: "only the enabled controllers of several are started",
+			fakes: []*fakeController{
+				{name: "epever", enabled: true},
+				{name: "voltgo", enabled: false},
+			},
+			expected: []string{"epever"},
+		},
+		{
+			name: "every enabled controller is started",
+			fakes: []*fakeController{
+				{name: "epever", enabled: true},
+				{name: "voltgo", enabled: true},
+			},
+			expected: []string{"epever", "voltgo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factories := make([]controllerFactory, 0, len(tt.fakes))
+			for _, fake := range tt.fakes {
+				factories = append(factories, newFakeFactory(fake))
+			}
+
+			app, err := newApplication(minimalConfig(), testutil.NewMockPublisher(), getTestVersionInfo(), factories)
+			require.NoError(t, err)
+			defer app.Close()
+
+			built := make([]string, 0, len(app.controllers))
+			for _, controller := range app.controllers {
+				built = append(built, controller.(*fakeController).name)
+			}
+			assert.Equal(t, tt.expected, nilIfEmpty(built))
+
+			// Only started controllers get their endpoints registered.
+			for _, fake := range tt.fakes {
+				assert.Equal(t, fake.enabled, fake.registered,
+					"controller %q registered=%v but enabled=%v", fake.name, fake.registered, fake.enabled)
+			}
+		})
+	}
+}
+
+func nilIfEmpty(names []string) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+// registeredPaths returns the paths the router actually has routes for.
+func registeredPaths(app *Application) []string {
+	routes := app.Router().Routes()
+	paths := make([]string, 0, len(routes))
+	for _, route := range routes {
+		paths = append(paths, route.Path)
+	}
+	return paths
+}
+
+// The publisher is the only path metrics take off the device, so a controller
+// built without it would collect and silently discard everything.
+func TestBuildControllers_EveryControllerReceivesThePublisher(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	epeverFake := &fakeController{name: "epever", enabled: true}
+	voltgoFake := &fakeController{name: "voltgo", enabled: true}
+	publisher := testutil.NewMockPublisher()
+
+	app, err := newApplication(
+		minimalConfig(),
+		publisher,
+		getTestVersionInfo(),
+		[]controllerFactory{newFakeFactory(epeverFake), newFakeFactory(voltgoFake)},
+	)
+	require.NoError(t, err)
+	defer app.Close()
+
+	assert.Same(t, publisher, epeverFake.publisher, "epever was built without the configured publisher")
+	assert.Same(t, publisher, voltgoFake.publisher, "voltgo was built without the configured publisher")
+}
+
+func TestBuildControllers_ConstructorFailureNamesTheController(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	factories := []controllerFactory{{
+		name: "epever",
+		build: func(*config.SolarControllerConfiguration, publish.MessagePublisher) (controllers.SolarController, error) {
+			return nil, errors.New("serial port unavailable")
+		},
+	}}
+
+	_, err := newApplication(minimalConfig(), testutil.NewMockPublisher(), getTestVersionInfo(), factories)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "epever")
+	assert.Contains(t, err.Error(), "serial port unavailable")
+}
+
+func TestClose_ClosesEveryStartedController(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	started := &fakeController{name: "epever", enabled: true}
+	notStarted := &fakeController{name: "voltgo", enabled: false}
+
+	app, err := newApplication(
+		minimalConfig(),
+		testutil.NewMockPublisher(),
+		getTestVersionInfo(),
+		[]controllerFactory{newFakeFactory(started), newFakeFactory(notStarted)},
+	)
+	require.NoError(t, err)
+	require.NoError(t, app.Close())
+
+	assert.True(t, started.closed, "a started controller was not closed on shutdown")
+	assert.False(t, notStarted.closed, "a controller that never started should not be closed")
+}
+
+// The production wiring must list every controller the binary supports;
+// otherwise a controller can be added and silently never started.
+func TestDefaultControllerFactories(t *testing.T) {
+	names := make([]string, 0)
+	for _, factory := range defaultControllerFactories() {
+		names = append(names, factory.name)
+	}
+
+	assert.Equal(t, []string{"epever"}, names)
+}
+
+// The real epever constructor is exercised here rather than through a fake, so
+// the config-to-controller decision is checked against the actual code path for
+// the two cases that do not need hardware.
+func TestDefaultFactories_EpeverNotStartedWithoutSerialPort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "disabled", enabled: false},
+		{name: "enabled but no serial port", enabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.SolarController.Epever.Enabled = tt.enabled
+
+			app, err := NewApplication(cfg, testutil.NewMockPublisher(), getTestVersionInfo())
+			require.NoError(t, err)
+			defer app.Close()
+
+			assert.Empty(t, app.controllers)
+
+			// Asserted against the router's route table rather than by making a
+			// request: the SPA fallback answers 200 with index.html for any
+			// unmatched path, so a status code cannot show a route is absent.
+			assert.NotContains(t, registeredPaths(app), "/api/epever/metrics",
+				"epever endpoints were registered for a controller that never started")
+		})
+	}
+}

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Enforces both a per-package coverage floor and an overall total.
+#
+# A total-only gate lets a badly tested package hide behind well tested ones:
+# internal/controllers/epever holds most of the statements in this module, so a
+# change that guts its coverage can still raise the total by adding a small,
+# heavily tested package. The per-package floors in scripts/coverage-floors.txt
+# close that gap.
+#
+# Usage: check-coverage.sh <coverage-profile> <floors-file> <total-threshold>
+
+set -euo pipefail
+
+profile="${1:?usage: check-coverage.sh <coverage-profile> <floors-file> <total-threshold>}"
+floors="${2:?missing floors file}"
+total_threshold="${3:?missing total threshold}"
+
+for f in "$profile" "$floors"; do
+  if [ ! -f "$f" ]; then
+    echo "check-coverage: $f not found" >&2
+    exit 2
+  fi
+done
+
+module="$(go list -m)"
+
+# Packages deliberately outside the gate:
+#   internal/testutil            - test helpers, exercised only via other tests
+#   site/node_modules            - third-party Go code vendored inside an npm
+#                                  package; ./... picks it up but it is not ours
+awk \
+  -v module_prefix="${module}/" \
+  -v floors_file="$floors" \
+  -v total_threshold="$total_threshold" '
+function is_excluded(pkg) {
+  return pkg ~ /^internal\/testutil/ || pkg ~ /^site\/node_modules/
+}
+
+BEGIN {
+  while ((getline line < floors_file) > 0) {
+    sub(/#.*/, "", line)
+    if (split(line, field, " ") < 2) continue
+    floor[field[1]] = field[2]
+    listed[field[1]] = 1
+  }
+  close(floors_file)
+}
+
+# Skip the profile header, e.g. "mode: set"
+/^mode:/ { next }
+
+{
+  split($1, location, ":")
+  path = location[1]
+  sub(module_prefix, "", path)
+
+  # Package is the file path minus the file name
+  depth = split(path, segment, "/")
+  pkg = segment[1]
+  for (i = 2; i < depth; i++) pkg = pkg "/" segment[i]
+
+  if (is_excluded(pkg)) next
+
+  statements[pkg] += $2
+  if ($3 > 0) covered[pkg] += $2
+  seen[pkg] = 1
+}
+
+END {
+  # A listed package with no profile entries has no tests at all, so it counts
+  # as 0% rather than disappearing from the report.
+  for (pkg in floor) if (!(pkg in seen)) { seen[pkg] = 1; statements[pkg] = 0; covered[pkg] = 0 }
+
+  count = 0
+  for (pkg in seen) ordered[++count] = pkg
+  for (i = 1; i <= count; i++)
+    for (j = i + 1; j <= count; j++)
+      if (ordered[j] < ordered[i]) { swap = ordered[i]; ordered[i] = ordered[j]; ordered[j] = swap }
+
+  printf "%-40s %8s %8s\n", "PACKAGE", "ACTUAL", "FLOOR"
+
+  failures = 0
+  total_statements = 0
+  total_covered = 0
+
+  for (i = 1; i <= count; i++) {
+    pkg = ordered[i]
+    pct = statements[pkg] > 0 ? 100 * covered[pkg] / statements[pkg] : 0
+    total_statements += statements[pkg]
+    total_covered += covered[pkg]
+
+    if (!(pkg in listed)) {
+      printf "%-40s %7.1f%% %8s  UNLISTED\n", pkg, pct, "-"
+      unlisted[++unlisted_count] = pkg
+      failures++
+      continue
+    }
+
+    # Compared at one decimal place, matching the reported figure, so a package
+    # is never failed for a difference the report cannot show.
+    if (sprintf("%.1f", pct) + 0 < floor[pkg] + 0) {
+      printf "%-40s %7.1f%% %7d%%  BELOW FLOOR\n", pkg, pct, floor[pkg]
+      failures++
+    } else {
+      printf "%-40s %7.1f%% %7d%%\n", pkg, pct, floor[pkg]
+    }
+  }
+
+  total_pct = total_statements > 0 ? 100 * total_covered / total_statements : 0
+  printf "%-40s %7.1f%% %7d%%\n", "TOTAL", total_pct, total_threshold
+
+  total_failed = (sprintf("%.1f", total_pct) + 0 < total_threshold + 0)
+
+  if (!failures && !total_failed) exit 0
+
+  print ""
+  if (unlisted_count > 0) {
+    for (i = 1; i <= unlisted_count; i++)
+      printf "FAIL: %s is not in %s. Add it with a floor equal to its current coverage.\n", unlisted[i], floors_file
+  }
+  for (i = 1; i <= count; i++) {
+    pkg = ordered[i]
+    if (!(pkg in listed)) continue
+    pct = statements[pkg] > 0 ? 100 * covered[pkg] / statements[pkg] : 0
+    if (sprintf("%.1f", pct) + 0 < floor[pkg] + 0)
+      printf "FAIL: %s coverage %.1f%% is below its floor of %d%%.\n", pkg, pct, floor[pkg]
+  }
+  if (total_failed)
+    printf "FAIL: total coverage %.1f%% is below the threshold of %d%%.\n", total_pct, total_threshold
+
+  exit 1
+}
+' "$profile"

--- a/scripts/coverage-floors.txt
+++ b/scripts/coverage-floors.txt
@@ -1,0 +1,36 @@
+# Minimum statement coverage per package, enforced by scripts/check-coverage.sh
+# on every `make test-coverage` run.
+#
+# These are a ratchet, not a target: each floor is the coverage measured when it
+# was recorded, rounded down. That means the gate cannot regress a package, and
+# it does not fail the build today. Raise a floor when you raise its coverage —
+# never lower one to make a build pass.
+#
+# Every package in the coverage profile must be listed here. An unlisted package
+# fails the check, so adding a package forces a deliberate decision about its
+# floor rather than letting it slip in invisibly.
+#
+# A package with no test files produces no entries in the coverage profile and is
+# therefore measured as 0%. Those are listed explicitly with a floor of 0 so they
+# are visible as gaps rather than silently absent.
+#
+# Format: <package path relative to the module root> <floor percentage>
+
+cmd/controller                       46
+internal/app                         92
+internal/config                      100
+internal/controllers/epever          56
+internal/controllers/epever/parser   97
+internal/controllers/voltgo          81
+internal/publishers                  90
+internal/publishers/file             92
+internal/publishers/mqtt             73
+internal/publishers/remotewrite      84
+internal/publishers/sns              40
+internal/publishers/solace           34
+
+# No tests yet. Both are real gaps, not exemptions:
+#   internal/publish  - MessagePublisher interface and NoOpPublisher
+#   internal/static   - embedded SPA filesystem and fallback routing
+internal/publish                     0
+internal/static                      0


### PR DESCRIPTION
## Per-package coverage floors (#173)

`make test-coverage` now enforces a floor for every package in addition to the total, via `scripts/check-coverage.sh` reading `scripts/coverage-floors.txt`.

Each floor is the coverage measured now, rounded down — a ratchet that cannot regress, not a cliff that fails today. Raise a floor as coverage improves (#129, #130, #143); never lower one to make a build pass.

Two deliberate decisions the issue asked for:

- **Unlisted packages fail.** Adding a package forces a conscious choice about its floor rather than letting it in unmeasured.
- **Packages with no test files count as 0%, not exempt.** `internal/publish` and `internal/static` produce no profile entries; they are listed at `0` so they stay visible as gaps.

`internal/testutil` and the third-party Go package vendored inside `site/node_modules` are the only exclusions.

Failure output names the package and shows measured vs required:

```
internal/publishers/solace                  34.5%      60%  BELOW FLOOR
...
FAIL: internal/publishers/solace coverage 34.5% is below its floor of 60%.
```

The total threshold is untouched at 62 — #143 owns that number, and this issue is about the shape of the gate.

## cmd/controller coverage and wiring tests (#174)

**The issue's premise is stale in one respect:** `buildControllers()` is no longer in `main.go`, it moved to `internal/app`. So this splits accordingly.

`cmd/controller`: `main()` called `log.Fatalf` inline, so no part of startup could be driven from a test. Config loading, debug resolution, logging setup and version info are now functions returning errors, with `main()` reduced to flag parsing and turning a failure into an exit. **0% → 46.9%.**

`internal/app`: the wiring genuinely could not be tested before — the epever constructor calls `handler.Connect()` eagerly, so the enabled path is unreachable without a serial port, and the existing registration test covers two cases that both expect nothing to be built. `buildControllers` now iterates a list of controller factories, so tests can assert which controllers are built per config (including enabled-but-misconfigured), that each receives the configured publisher, that only started controllers register endpoints and are closed, and that a constructor failure names the controller. **82.5% → 92.5%.** The two cases reachable without hardware are still exercised through the real epever constructor.

## Testing

- Gate verified against the real profile in all five states: passing (exit 0), one package below floor while the total still passes (exit 1), unlisted package (exit 1), total below threshold (exit 1), and a package regressed to 0% (exit 1).
- The publisher-wiring assertion was **mutation tested**: handing controllers `nil` instead of `a.publisher` fails it.
- `golangci-lint run ./...` clean, `shellcheck scripts/check-coverage.sh` clean, `go vet` clean.
- All Go tests pass under `-race` (12 packages, exit 0).

## Toolchain note (resolved)

`make test-coverage` initially could not be run end to end on my machine: it failed with `go: no such tool "covdata"` for the packages that have no test files. That has since been fixed and **the full gate now passes locally, exit 0**.

The cause was not a corrupted install. Go 1.25 ships no prebuilt `covdata` binary at all — the official `go1.25.12.darwin-arm64` archive contains only 7 tools (`asm`, `cgo`, `compile`, `cover`, `link`, `preprofile`, `vet`) and builds the rest on demand. That on-demand build does not work when `GOROOT` is the read-only toolchain module the `go` command auto-downloads into the module cache, which is what `GOTOOLCHAIN=auto` was doing here because the locally installed Go was 1.24.5 while `go.mod` requires 1.25.0. Installing a real Go 1.25.12 (writable `GOROOT`) resolves it. CI was never affected, because `setup-go` installs to a writable location.

One number changed as a result: the measured total is **66.5%, not 67.0%**. With the broken toolchain, `internal/publish` and `internal/static` produced no profile entries at all and contributed zero statements; now they contribute their statements at 0% covered. 66.5% is the more accurate figure and is what CI measures. **No per-package floor changed** — every recorded floor still matches its measured value exactly.

This also means the gate's exclusion logic (`internal/testutil`, `site/node_modules`) is now genuinely exercised rather than incidentally unreachable: both appear in the profile and are correctly skipped.

Endpoint presence is asserted against the router's route table rather than by making a request: the SPA fallback answers 200 for any unmatched path, so a status code cannot show a route is absent (related to #124).

## Stacked

Based on `feat/frontend-tests-and-types` (#177), which is itself based on `chore/ci-quality-gates` (#176). Review those first; this diff is against #177.

Fixes #173
Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

