### PR TITLE
chore: Wire voltgo into config and app bootstrap

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lumberbarons/solar-controller/internal/config"
 	"github.com/lumberbarons/solar-controller/internal/controllers"
 	"github.com/lumberbarons/solar-controller/internal/controllers/epever"
+	"github.com/lumberbarons/solar-controller/internal/controllers/voltgo"
 	"github.com/lumberbarons/solar-controller/internal/publish"
 	staticfs "github.com/lumberbarons/solar-controller/internal/static"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -49,6 +50,12 @@ func defaultControllerFactories() []controllerFactory {
 			name: "epever",
 			build: func(cfg *config.SolarControllerConfiguration, publisher publish.MessagePublisher) (controllers.SolarController, error) {
 				return epever.NewControllerFromConfig(cfg.Epever, publisher, cfg.DeviceID)
+			},
+		},
+		{
+			name: "voltgo",
+			build: func(cfg *config.SolarControllerConfiguration, publisher publish.MessagePublisher) (controllers.SolarController, error) {
+				return voltgo.NewControllerFromConfig(cfg.Voltgo, publisher, cfg.DeviceID)
 			},
 		},
 	}

--- a/internal/app/wiring_test.go
+++ b/internal/app/wiring_test.go
@@ -213,7 +213,7 @@ func TestDefaultControllerFactories(t *testing.T) {
 		names = append(names, factory.name)
 	}
 
-	assert.Equal(t, []string{"epever"}, names)
+	assert.Equal(t, []string{"epever", "voltgo"}, names)
 }
 
 // The real epever constructor is exercised here rather than through a fake, so
@@ -246,6 +246,39 @@ func TestDefaultFactories_EpeverNotStartedWithoutSerialPort(t *testing.T) {
 			// unmatched path, so a status code cannot show a route is absent.
 			assert.NotContains(t, registeredPaths(app), "/api/epever/metrics",
 				"epever endpoints were registered for a controller that never started")
+		})
+	}
+}
+
+// As for epever above, the real voltgo constructor is used. The enabled-with-an-
+// address case is absent because that path opens a BLE adapter, which no CI
+// machine has.
+func TestDefaultFactories_VoltgoNotStartedWithoutAddress(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "disabled", enabled: false},
+		{name: "enabled but no address", enabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.SolarController.Voltgo.Enabled = tt.enabled
+
+			app, err := NewApplication(cfg, testutil.NewMockPublisher(), getTestVersionInfo())
+			require.NoError(t, err)
+			defer app.Close()
+
+			assert.Empty(t, app.controllers)
+
+			assert.NotContains(t, registeredPaths(app), "/api/voltgo/metrics",
+				"voltgo endpoints were registered for a controller that never started")
+			assert.NotContains(t, registeredPaths(app), "/api/voltgo/info",
+				"voltgo endpoints were registered for a controller that never started")
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lumberbarons/solar-controller/internal/controllers/epever"
+	"github.com/lumberbarons/solar-controller/internal/controllers/voltgo"
 	"github.com/lumberbarons/solar-controller/internal/publishers/file"
 	"github.com/lumberbarons/solar-controller/internal/publishers/mqtt"
 	"github.com/lumberbarons/solar-controller/internal/publishers/remotewrite"
@@ -29,6 +30,7 @@ type SolarControllerConfiguration struct {
 	File        file.Configuration        `yaml:"file"`
 	RemoteWrite remotewrite.Configuration `yaml:"remoteWrite"`
 	Epever      epever.Configuration      `yaml:"epever"`
+	Voltgo      voltgo.Configuration      `yaml:"voltgo"`
 }
 
 // AuthConfiguration holds API authentication settings. When Token is set,
@@ -161,6 +163,19 @@ func (c *Config) Validate() error {
 		}
 		if c.SolarController.Epever.PublishPeriod <= 0 {
 			return fmt.Errorf("epever publish period must be positive")
+		}
+	}
+
+	// Validate Voltgo configuration if enabled
+	if c.SolarController.Voltgo.Enabled {
+		if c.SolarController.Voltgo.Address == "" {
+			return fmt.Errorf("voltgo address is required when voltgo is enabled")
+		}
+		if c.SolarController.Voltgo.PublishPeriod <= 0 {
+			return fmt.Errorf("voltgo publish period must be positive")
+		}
+		if err := c.SolarController.Voltgo.Validate(); err != nil {
+			return fmt.Errorf("invalid voltgo configuration: %w", err)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,8 +3,10 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lumberbarons/solar-controller/internal/controllers/epever"
+	"github.com/lumberbarons/solar-controller/internal/controllers/voltgo"
 	"github.com/lumberbarons/solar-controller/internal/publishers/file"
 	"github.com/lumberbarons/solar-controller/internal/publishers/mqtt"
 	"github.com/lumberbarons/solar-controller/internal/publishers/sns"
@@ -255,6 +257,105 @@ solarController:
 `,
 			wantErr: true,
 			errMsg:  "epever publish period must be positive",
+		},
+		{
+			name: "voltgo configuration valid with all fields",
+			yaml: `
+solarController:
+  httpPort: 8080
+  epever:
+    enabled: false
+  voltgo:
+    enabled: true
+    address: AA:BB:CC:DD:EE:FF
+    publishPeriod: 120
+    connectTimeout: 45s
+`,
+			wantErr: false,
+			check: func(t *testing.T, c Config) {
+				if !c.SolarController.Voltgo.Enabled {
+					t.Error("Voltgo should be enabled")
+				}
+				if c.SolarController.Voltgo.Address != "AA:BB:CC:DD:EE:FF" {
+					t.Errorf("Voltgo Address = %s, want AA:BB:CC:DD:EE:FF", c.SolarController.Voltgo.Address)
+				}
+				if c.SolarController.Voltgo.PublishPeriod != 120 {
+					t.Errorf("Voltgo PublishPeriod = %d, want 120", c.SolarController.Voltgo.PublishPeriod)
+				}
+				if got := c.SolarController.Voltgo.GetConnectTimeout(); got != 45*time.Second {
+					t.Errorf("Voltgo ConnectTimeout = %s, want 45s", got)
+				}
+			},
+		},
+		{
+			name: "voltgo disabled needs no other fields",
+			yaml: `
+solarController:
+  httpPort: 8080
+  epever:
+    enabled: false
+  voltgo:
+    enabled: false
+`,
+			wantErr: false,
+			check: func(t *testing.T, c Config) {
+				if c.SolarController.Voltgo.Enabled {
+					t.Error("Voltgo should be disabled")
+				}
+			},
+		},
+		{
+			name: "voltgo enabled but no address",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    address: ""
+    publishPeriod: 60
+`,
+			wantErr: true,
+			errMsg:  "voltgo address is required",
+		},
+		{
+			name: "voltgo enabled but zero publish period",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    address: AA:BB:CC:DD:EE:FF
+    publishPeriod: 0
+`,
+			wantErr: true,
+			errMsg:  "voltgo publish period must be positive",
+		},
+		{
+			name: "voltgo enabled but negative publish period",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    address: AA:BB:CC:DD:EE:FF
+    publishPeriod: -10
+`,
+			wantErr: true,
+			errMsg:  "voltgo publish period must be positive",
+		},
+		{
+			name: "voltgo enabled but unparseable connect timeout",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    address: AA:BB:CC:DD:EE:FF
+    publishPeriod: 60
+    connectTimeout: not-a-duration
+`,
+			wantErr: true,
+			errMsg:  "invalid voltgo configuration",
 		},
 		{
 			name: "MQTT configuration valid with all fields",
@@ -786,6 +887,59 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "epever publish period must be positive",
+		},
+		{
+			name: "Voltgo enabled but no address",
+			config: Config{
+				SolarController: SolarControllerConfiguration{
+					HTTPPort: 8080,
+					Voltgo:   voltgo.Configuration{Enabled: true, Address: "", PublishPeriod: 60},
+				},
+			},
+			wantErr: true,
+			errMsg:  "voltgo address is required",
+		},
+		{
+			name: "Voltgo enabled but zero publish period",
+			config: Config{
+				SolarController: SolarControllerConfiguration{
+					HTTPPort: 8080,
+					Voltgo:   voltgo.Configuration{Enabled: true, Address: "AA:BB:CC:DD:EE:FF", PublishPeriod: 0},
+				},
+			},
+			wantErr: true,
+			errMsg:  "voltgo publish period must be positive",
+		},
+		{
+			name: "Voltgo enabled but unparseable connect timeout",
+			config: Config{
+				SolarController: SolarControllerConfiguration{
+					HTTPPort: 8080,
+					Voltgo: voltgo.Configuration{
+						Enabled:        true,
+						Address:        "AA:BB:CC:DD:EE:FF",
+						PublishPeriod:  60,
+						ConnectTimeout: "not-a-duration",
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "invalid voltgo configuration",
+		},
+		{
+			name: "Voltgo enabled and fully configured",
+			config: Config{
+				SolarController: SolarControllerConfiguration{
+					HTTPPort: 8080,
+					Voltgo: voltgo.Configuration{
+						Enabled:        true,
+						Address:        "AA:BB:CC:DD:EE:FF",
+						PublishPeriod:  60,
+						ConnectTimeout: "45s",
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
### What

Adds voltgo to SolarControllerConfiguration and registers it in defaultControllerFactories, so a configured voltgo battery is built and started at bootstrap.

### Why

Wire the voltgo controller into configuration and application bootstrap.

### Testing

make test-coverage (config holds 100%, app 92.6%, total 66.7% over the 62% floor); golangci-lint clean.

Fixes #123
Part of #137