### PR TITLE
feat: add voltgo battery panel to the web UI

### DIFF
--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -11,7 +11,10 @@
     "    match the lists below.",
     "",
     "Renaming a field on either side therefore fails CI until this file and the",
-    "other side are updated to agree. Keep each list sorted."
+    "other side are updated to agree. Keep each list sorted.",
+    "",
+    "An entry named '<endpoint>#<field>[]' records the fields of the objects",
+    "inside a nested array, which a top-level field list would not cover."
   ],
   "endpoints": {
     "GET /api/info": [
@@ -62,6 +65,28 @@
     ],
     "GET /api/epever/time": [
       "time"
+    ],
+    "GET /api/voltgo/metrics": [
+      "cellCount",
+      "cells",
+      "collectionTime",
+      "current",
+      "soc",
+      "soh",
+      "temperature",
+      "temperatures",
+      "timestamp",
+      "voltage"
+    ],
+    "GET /api/voltgo/metrics#cells[]": [
+      "index",
+      "voltage"
+    ],
+    "GET /api/voltgo/info": [
+      "capacityAh",
+      "chemistry",
+      "deviceStrings",
+      "nominalVoltage"
     ]
   }
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -177,8 +177,18 @@ func (a *Application) setupRoutes() {
 	a.router.Use(static.Serve("/", siteFS))
 
 	// SPA fallback: serve index.html for any route that doesn't match
-	// This allows React Router to handle client-side routing
+	// This allows React Router to handle client-side routing.
+	//
+	// /api paths are excluded: a controller that is disabled registers no
+	// endpoints, and serving index.html for its URLs would answer an API
+	// request with 200 and a page of HTML. The frontend uses 404 to decide a
+	// controller is absent and hide its panel, so unmatched API routes must
+	// say so rather than fall through to the SPA.
 	a.router.NoRoute(func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.FileFromFS("/", siteFS)
 	})
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -183,6 +183,35 @@ func TestApplication_SPAFallback(t *testing.T) {
 	}
 }
 
+// The frontend hides a controller's panel when its endpoint 404s, so an
+// unmatched /api route must not be swallowed by the SPA fallback.
+func TestApplication_UnmatchedAPIRouteReturnsJSON404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{
+		SolarController: config.SolarControllerConfiguration{
+			HTTPPort: 8080,
+			Epever:   epever.Configuration{Enabled: false},
+		},
+	}
+
+	app, err := NewApplication(cfg, testutil.NewMockPublisher(), getTestVersionInfo())
+	require.NoError(t, err)
+	defer app.Close()
+
+	for _, path := range []string{"/api/voltgo/metrics", "/api/epever/metrics", "/api/nonsense"} {
+		t.Run(path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", path, nil)
+			app.Router().ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+			assert.NotContains(t, w.Body.String(), "<!doctype html>")
+		})
+	}
+}
+
 func TestApplication_AuthMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -382,10 +411,11 @@ func TestApplication_ControllerRegistration(t *testing.T) {
 				assert.NotEqual(t, http.StatusNotFound, w.Code)
 				assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
 			} else {
-				// With NoRoute handler, unmatched routes return 200 with index.html (SPA fallback)
-				// We verify the endpoint doesn't exist by checking it returns HTML, not JSON
-				assert.Equal(t, http.StatusOK, w.Code)
-				assert.NotContains(t, w.Header().Get("Content-Type"), "application/json")
+				// Unmatched /api routes are answered with a JSON 404 rather than
+				// the SPA fallback, so the frontend can tell a disabled
+				// controller from one that is merely slow to report.
+				assert.Equal(t, http.StatusNotFound, w.Code)
+				assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
 			}
 		})
 	}

--- a/internal/controllers/voltgo/api_contract_test.go
+++ b/internal/controllers/voltgo/api_contract_test.go
@@ -1,0 +1,49 @@
+package voltgo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lumberbarons/solar-controller/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MetricsGet and InfoGet serialise the collector structs directly, so their
+// json tags are the wire contract. These tests pin those tags against
+// docs/api-contract.json, which site/src/api/types.ts is checked against from
+// the other side, so a rename cannot reach the browser as `undefined`.
+func TestStatusPayloadMatchesAPIContract(t *testing.T) {
+	payload, err := json.Marshal(BatteryStatus{})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		testutil.APIContractFields(t, "GET /api/voltgo/metrics"),
+		testutil.JSONFieldNames(t, payload),
+		"BatteryStatus no longer marshals to the fields docs/api-contract.json "+
+			"records; update the contract and site/src/api/types.ts together")
+}
+
+// JSONFieldNames only sees top-level keys, so the per-cell objects the battery
+// panel reads need checking on their own.
+func TestCellPayloadMatchesAPIContract(t *testing.T) {
+	payload, err := json.Marshal(Cell{})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		testutil.APIContractFields(t, "GET /api/voltgo/metrics#cells[]"),
+		testutil.JSONFieldNames(t, payload),
+		"Cell no longer marshals to the fields docs/api-contract.json records; "+
+			"update the contract and site/src/api/types.ts together")
+}
+
+func TestInfoPayloadMatchesAPIContract(t *testing.T) {
+	payload, err := json.Marshal(BatteryInfo{})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		testutil.APIContractFields(t, "GET /api/voltgo/info"),
+		testutil.JSONFieldNames(t, payload),
+		"BatteryInfo no longer marshals to the fields docs/api-contract.json "+
+			"records; update the contract and site/src/api/types.ts together")
+}

--- a/scripts/coverage-floors.txt
+++ b/scripts/coverage-floors.txt
@@ -17,7 +17,7 @@
 # Format: <package path relative to the module root> <floor percentage>
 
 cmd/controller                       46
-internal/app                         92
+internal/app                         93
 internal/config                      100
 internal/controllers/epever          56
 internal/controllers/epever/parser   97

--- a/site/src/api/types.test.ts
+++ b/site/src/api/types.test.ts
@@ -10,6 +10,9 @@ import {
   INFO_FIELDS,
   METRIC_FIELDS,
   TIME_FIELDS,
+  VOLTGO_CELL_FIELDS,
+  VOLTGO_INFO_FIELDS,
+  VOLTGO_METRIC_FIELDS,
 } from './types';
 
 /**
@@ -57,6 +60,9 @@ describe('API contract', () => {
     ['GET /api/epever/battery-profile', BATTERY_PROFILE_FIELDS],
     ['GET /api/epever/charging-parameters', CHARGING_PARAMETER_FIELDS],
     ['GET /api/epever/time', TIME_FIELDS],
+    ['GET /api/voltgo/metrics', VOLTGO_METRIC_FIELDS],
+    ['GET /api/voltgo/metrics#cells[]', VOLTGO_CELL_FIELDS],
+    ['GET /api/voltgo/info', VOLTGO_INFO_FIELDS],
   ])('%s declares the fields the Go handler returns', (endpoint, declared) => {
     expect([...declared].sort()).toEqual(contractFields(endpoint));
   });

--- a/site/src/api/types.ts
+++ b/site/src/api/types.ts
@@ -49,6 +49,70 @@ export const CHARGING_STATUS_LABELS: Record<number, string> = {
   3: 'Equalization',
 };
 
+/** GET /api/voltgo/metrics */
+export const VOLTGO_METRIC_FIELDS = [
+  'cellCount',
+  'cells',
+  'collectionTime',
+  'current',
+  'soc',
+  'soh',
+  'temperature',
+  'temperatures',
+  'timestamp',
+  'voltage',
+] as const;
+
+/** The objects inside the `cells` array of GET /api/voltgo/metrics. */
+export const VOLTGO_CELL_FIELDS = ['index', 'voltage'] as const;
+
+export type VoltgoCell = {
+  index: number;
+  voltage: number;
+};
+
+/**
+ * Value types per field. VoltgoMetrics is mapped over VOLTGO_METRIC_FIELDS
+ * rather than declared directly, so the field list stays authoritative: a field
+ * added to the list without a type here fails the type check.
+ */
+type VoltgoMetricTypes = {
+  timestamp: number;
+  collectionTime: number;
+  voltage: number;
+  /** Pack current: positive while charging, negative while discharging. */
+  current: number;
+  soc: number;
+  soh: number;
+  temperature: number;
+  temperatures: number[];
+  cellCount: number;
+  cells: VoltgoCell[];
+};
+
+export type VoltgoMetrics = {
+  [K in (typeof VOLTGO_METRIC_FIELDS)[number]]: VoltgoMetricTypes[K];
+};
+
+/** GET /api/voltgo/info */
+export const VOLTGO_INFO_FIELDS = [
+  'capacityAh',
+  'chemistry',
+  'deviceStrings',
+  'nominalVoltage',
+] as const;
+
+type VoltgoInfoTypes = {
+  chemistry: string;
+  nominalVoltage: number;
+  capacityAh: number;
+  deviceStrings: string[];
+};
+
+export type VoltgoInfo = {
+  [K in (typeof VOLTGO_INFO_FIELDS)[number]]: VoltgoInfoTypes[K];
+};
+
 /** GET and PATCH /api/epever/battery-profile */
 export const BATTERY_PROFILE_FIELDS = [
   'batteryCapacity',

--- a/site/src/components/voltgo-battery.test.tsx
+++ b/site/src/components/voltgo-battery.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import VoltgoBattery from './voltgo-battery';
+import type { VoltgoInfo, VoltgoMetrics } from '../api/types';
+
+vi.mock('axios', () => {
+  const isAxiosError = (error: unknown): boolean =>
+    Boolean((error as { isAxiosError?: boolean } | null)?.isAxiosError);
+  return {
+    default: { get: vi.fn(), isAxiosError },
+  };
+});
+
+import axios from 'axios';
+
+const mockedGet = (axios as unknown as { get: Mock }).get;
+
+const METRICS: VoltgoMetrics = {
+  timestamp: 1699000000,
+  collectionTime: 1.8,
+  voltage: 13.31,
+  current: 12.4,
+  soc: 74,
+  soh: 99,
+  temperature: 19.5,
+  temperatures: [19, 20],
+  cellCount: 4,
+  cells: [
+    { index: 0, voltage: 3.331 },
+    { index: 1, voltage: 3.325 },
+    { index: 2, voltage: 3.338 },
+    { index: 3, voltage: 3.326 },
+  ],
+};
+
+const INFO: VoltgoInfo = {
+  chemistry: 'LiFePO4',
+  nominalVoltage: 12.8,
+  capacityAh: 100,
+  deviceStrings: ['VG-100'],
+};
+
+function httpError(status: number, statusText: string) {
+  const error = new Error(`Request failed with status code ${status}`) as Error & {
+    isAxiosError: boolean;
+    response: { status: number; statusText: string };
+  };
+  error.isAxiosError = true;
+  error.response = { status, statusText };
+  return error;
+}
+
+/** Answers each voltgo endpoint; anything not listed 404s, as an unregistered route does. */
+function mockApi(responses: Record<string, { status: number; data?: unknown }>) {
+  mockedGet.mockImplementation((url: string) => {
+    const response = responses[url];
+    if (!response) {
+      return Promise.reject(httpError(404, 'Not Found'));
+    }
+    return Promise.resolve({ status: response.status, data: response.data ?? '' });
+  });
+}
+
+const withMetrics = (metrics: VoltgoMetrics = METRICS) =>
+  mockApi({
+    '/api/voltgo/metrics': { status: 200, data: metrics },
+    '/api/voltgo/info': { status: 200, data: INFO },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('voltgo battery panel', () => {
+  it('renders the pack metrics', async () => {
+    withMetrics();
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+    expect(screen.getByText('13.31 V')).toBeInTheDocument();
+    expect(screen.getByText('99 %')).toBeInTheDocument();
+    expect(screen.getByText('19.5 °C')).toBeInTheDocument();
+  });
+
+  it('shows the battery description once the info endpoint answers', async () => {
+    withMetrics();
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('LiFePO4 · 12.8 V · 100 Ah')).toBeInTheDocument(),
+    );
+  });
+
+  it('still renders the pack when the info endpoint has no data yet', async () => {
+    mockApi({
+      '/api/voltgo/metrics': { status: 200, data: METRICS },
+      '/api/voltgo/info': { status: 204 },
+    });
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+    expect(screen.queryByText(/LiFePO4/)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [12.4, '+12.40 A', 'Charging'],
+    [-8.75, '-8.75 A', 'Discharging'],
+    [0.01, '+0.01 A', 'Idle'],
+    [-0.01, '-0.01 A', 'Idle'],
+  ])('renders current %p as %s (%s)', async (current, displayed, flow) => {
+    withMetrics({ ...METRICS, current });
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() => expect(screen.getByText(displayed)).toBeInTheDocument());
+    expect(screen.getByText(flow)).toBeInTheDocument();
+  });
+
+  it('highlights the highest and lowest cell and reports the spread', async () => {
+    withMetrics();
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Cell 2 · 3.338 V (highest)')).toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText('Cell 1 · 3.325 V (lowest)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cell 0 · 3.331 V')).toBeInTheDocument();
+    expect(screen.getByText('Cells (4) · spread 13 mV')).toBeInTheDocument();
+  });
+
+  it('marks no cell as an outlier when they all read the same', async () => {
+    withMetrics({
+      ...METRICS,
+      cells: [
+        { index: 0, voltage: 3.33 },
+        { index: 1, voltage: 3.33 },
+      ],
+      cellCount: 2,
+    });
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() => expect(screen.getByLabelText('Cell 0 · 3.330 V')).toBeInTheDocument());
+    expect(screen.queryByLabelText(/highest/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/lowest/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the controller is disabled', async () => {
+    mockApi({});
+
+    const { container } = render(<VoltgoBattery refreshKey={0} />);
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo/metrics'));
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    expect(mockedGet).not.toHaveBeenCalledWith('/api/voltgo/info');
+  });
+
+  it('says it is waiting when no reading has arrived yet', async () => {
+    mockApi({ '/api/voltgo/metrics': { status: 204 } });
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    expect(
+      await screen.findByText('Waiting for the first battery reading.'),
+    ).toBeInTheDocument();
+  });
+
+  it('reports a failed fetch rather than rendering nothing', async () => {
+    mockedGet.mockRejectedValue(httpError(500, 'Internal Server Error'));
+
+    render(<VoltgoBattery refreshKey={0} />);
+
+    expect(
+      await screen.findByText('Failed to load battery metrics: 500 Internal Server Error'),
+    ).toBeInTheDocument();
+  });
+
+  it('refetches when refreshKey changes', async () => {
+    withMetrics();
+
+    const { rerender } = render(<VoltgoBattery refreshKey={0} />);
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+
+    withMetrics({ ...METRICS, soc: 81 });
+    rerender(<VoltgoBattery refreshKey={1} />);
+
+    await waitFor(() => expect(screen.getByText('81 %')).toBeInTheDocument());
+  });
+});

--- a/site/src/components/voltgo-battery.tsx
+++ b/site/src/components/voltgo-battery.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import axios from 'axios';
+import { Alert, Box, Chip, Grid, Stack, Typography } from '@mui/material';
+
+import Metric from './metric';
+import type { VoltgoCell, VoltgoInfo, VoltgoMetrics } from '../api/types';
+
+/**
+ * Below this many amps the pack is reported as idle rather than charging or
+ * discharging: a resting pack still reads a few tens of milliamps, and flipping
+ * the label on that noise reads as a fault to anyone watching the dashboard.
+ */
+const IDLE_CURRENT_THRESHOLD_A = 0.05;
+
+type PanelState =
+  /** The first fetch has not settled yet. */
+  | { kind: 'loading' }
+  /** No voltgo controller is running: the endpoint is not registered. */
+  | { kind: 'absent' }
+  /** Enabled, but no successful collection has happened yet (204). */
+  | { kind: 'pending' }
+  | { kind: 'ready'; metrics: VoltgoMetrics }
+  | { kind: 'error'; message: string };
+
+type VoltgoBatteryProps = {
+  /** Changing this triggers a refetch, so the dashboard refresh covers this panel too. */
+  refreshKey: number;
+};
+
+function describeFlow(current: number): string {
+  if (current > IDLE_CURRENT_THRESHOLD_A) {
+    return 'Charging';
+  }
+  if (current < -IDLE_CURRENT_THRESHOLD_A) {
+    return 'Discharging';
+  }
+  return 'Idle';
+}
+
+/** Signed, so the direction is readable from the number as well as the label. */
+function formatCurrent(current: number): string {
+  return `${current > 0 ? '+' : ''}${current.toFixed(2)}`;
+}
+
+function cellExtremes(cells: VoltgoCell[]): { min?: number; max?: number; spreadMv: number } {
+  if (cells.length === 0) {
+    return { spreadMv: 0 };
+  }
+  const voltages = cells.map(cell => cell.voltage);
+  const min = Math.min(...voltages);
+  const max = Math.max(...voltages);
+  return { min, max, spreadMv: (max - min) * 1000 };
+}
+
+function errorMessage(error: unknown): string {
+  if (axios.isAxiosError(error) && error.response) {
+    return `Failed to load battery metrics: ${error.response.status} ${error.response.statusText}`;
+  }
+  return `Failed to load battery metrics: ${(error as Error).message}`;
+}
+
+/**
+ * The battery pack reported by the voltgo BLE controller.
+ *
+ * Renders nothing when that controller is disabled — its endpoints are then
+ * unregistered and answer 404 — so a solar-only deployment sees no empty panel.
+ */
+function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
+  const [state, setState] = useState<PanelState>({ kind: 'loading' });
+  const [info, setInfo] = useState<VoltgoInfo | null>(null);
+
+  const fetchInfo = useCallback(() => {
+    axios.get<VoltgoInfo>('/api/voltgo/info')
+      .then(response => {
+        // 204 until the first connection has read the static info.
+        setInfo(response.status === 204 ? null : response.data);
+      })
+      .catch(() => {
+        // Info is decoration; the panel is useful without it.
+        setInfo(null);
+      });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    axios.get<VoltgoMetrics>('/api/voltgo/metrics')
+      .then(response => {
+        if (cancelled) {
+          return;
+        }
+        if (response.status === 204) {
+          setState({ kind: 'pending' });
+          return;
+        }
+        setState({ kind: 'ready', metrics: response.data });
+        fetchInfo();
+      })
+      .catch(error => {
+        if (cancelled) {
+          return;
+        }
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          setState({ kind: 'absent' });
+          return;
+        }
+        console.error('Failed to load voltgo battery metrics:', error);
+        setState({ kind: 'error', message: errorMessage(error) });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey, fetchInfo]);
+
+  if (state.kind === 'absent' || state.kind === 'loading') {
+    return null;
+  }
+
+  const heading = (
+    <Typography variant="h6" sx={{ mb: 1, fontWeight: 600, color: '#1b5e20' }}>
+      Battery Bank
+      {info && (
+        <Typography component="span" sx={{ ml: 1, fontSize: '0.875rem', color: 'text.secondary' }}>
+          {info.chemistry} · {info.nominalVoltage} V · {info.capacityAh} Ah
+        </Typography>
+      )}
+    </Typography>
+  );
+
+  if (state.kind === 'error') {
+    return (
+      <>
+        {heading}
+        <Alert severity="error" sx={{ mb: 2 }}>{state.message}</Alert>
+      </>
+    );
+  }
+
+  if (state.kind === 'pending') {
+    return (
+      <>
+        {heading}
+        <Alert severity="info" sx={{ mb: 2 }}>Waiting for the first battery reading.</Alert>
+      </>
+    );
+  }
+
+  const { metrics } = state;
+  const cells = metrics.cells ?? [];
+  const { min, max, spreadMv } = cellExtremes(cells);
+  const hasSpread = min !== undefined && max !== undefined && max > min;
+
+  return (
+    <>
+      {heading}
+      <Grid container spacing={2} sx={{ mb: 2 }}>
+        <Grid size={{ xs: 6, sm: 3 }}>
+          <Metric title="Battery SOC" value={metrics.soc} unit="%" />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 3 }}>
+          <Metric title="Battery Voltage" value={metrics.voltage} unit="V" />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 3 }}>
+          <Metric title="Battery Current" value={formatCurrent(metrics.current)} unit="A" />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 3 }}>
+          <Metric title="Battery Flow" value={describeFlow(metrics.current)} unit="" />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 3 }}>
+          <Metric title="Battery Health" value={metrics.soh} unit="%" />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 3 }}>
+          <Metric title="Battery Temp" value={metrics.temperature} unit="°C" />
+        </Grid>
+      </Grid>
+
+      {cells.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography sx={{ mb: 1, fontWeight: 600, color: '#1b5e20' }}>
+            Cells ({metrics.cellCount || cells.length}) · spread {spreadMv.toFixed(0)} mV
+          </Typography>
+          <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
+            {cells.map(cell => {
+              // Indices are the device's own, matching the `cell` label on the
+              // voltgo_cell_voltage Prometheus metric.
+              const label = `Cell ${cell.index} · ${cell.voltage.toFixed(3)} V`;
+              // A pack whose cells all read the same has no outlier to point
+              // at, so highlighting every chip would be noise.
+              const isMax = hasSpread && cell.voltage === max;
+              const isMin = hasSpread && cell.voltage === min;
+              const extreme = isMax ? ' (highest)' : isMin ? ' (lowest)' : '';
+              const borderColor = isMax ? '#c62828' : isMin ? '#1565c0' : 'rgba(0,0,0,0.23)';
+
+              return (
+                <Chip
+                  key={cell.index}
+                  label={label}
+                  aria-label={`${label}${extreme}`}
+                  variant="outlined"
+                  sx={{
+                    borderColor,
+                    borderWidth: isMax || isMin ? 2 : 1,
+                    fontWeight: isMax || isMin ? 600 : 400,
+                  }}
+                />
+              );
+            })}
+          </Stack>
+        </Box>
+      )}
+    </>
+  );
+}
+
+export default VoltgoBattery;

--- a/site/src/pages/main.test.tsx
+++ b/site/src/pages/main.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import Main from './main';
-import type { EpeverMetrics } from '../api/types';
+import type { EpeverMetrics, VoltgoMetrics } from '../api/types';
 
 vi.mock('axios', () => {
   const isAxiosError = (error: unknown): boolean =>
@@ -32,14 +32,63 @@ const METRICS: EpeverMetrics = {
   chargingStatus: 2,
 };
 
+const VOLTGO_METRICS: VoltgoMetrics = {
+  timestamp: 1699000000,
+  collectionTime: 1.8,
+  voltage: 13.31,
+  current: 12.4,
+  soc: 74,
+  soh: 99,
+  temperature: 19.5,
+  temperatures: [19, 20],
+  cellCount: 4,
+  cells: [
+    { index: 0, voltage: 3.331 },
+    { index: 1, voltage: 3.325 },
+    { index: 2, voltage: 3.338 },
+    { index: 3, voltage: 3.326 },
+  ],
+};
+
+const notFound = (): Promise<never> => {
+  const error = new Error('Request failed with status code 404') as Error & {
+    isAxiosError: boolean;
+    response: { status: number; statusText: string };
+  };
+  error.isAxiosError = true;
+  error.response = { status: 404, statusText: 'Not Found' };
+  return Promise.reject(error);
+};
+
+/**
+ * Routes by URL rather than answering every call with the same payload: the
+ * dashboard now fetches the voltgo battery endpoints too, and handing those the
+ * epever payload would test a response the backend never sends. Voltgo is
+ * absent unless a test says otherwise, which is what a solar-only deployment
+ * looks like.
+ */
+function mockApi(responses: Record<string, unknown> = {}) {
+  mockedGet.mockImplementation((url: string) => {
+    if (url in responses) {
+      return Promise.resolve({ status: 200, data: responses[url] });
+    }
+    if (url === '/api/epever/metrics') {
+      return Promise.resolve({ status: 200, data: METRICS });
+    }
+    return notFound();
+  });
+}
+
+const callCount = (url: string): number =>
+  mockedGet.mock.calls.filter(call => call[0] === url).length;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mockApi();
 });
 
 describe('dashboard', () => {
   it('renders the fetched metric values', async () => {
-    mockedGet.mockResolvedValue({ data: METRICS });
-
     render(<Main />);
 
     await waitFor(() => expect(screen.getByText('38.9 W')).toBeInTheDocument());
@@ -57,7 +106,7 @@ describe('dashboard', () => {
     [3, 'Equalization'],
     [9, 'Unknown'],
   ])('renders charging status code %i as %s', async (code, label) => {
-    mockedGet.mockResolvedValue({ data: { ...METRICS, chargingStatus: code } });
+    mockApi({ '/api/epever/metrics': { ...METRICS, chargingStatus: code } });
 
     render(<Main />);
 
@@ -71,7 +120,9 @@ describe('dashboard', () => {
     };
     error.isAxiosError = true;
     error.response = { status: 500, statusText: 'Internal Server Error' };
-    mockedGet.mockRejectedValue(error);
+    mockedGet.mockImplementation((url: string) =>
+      url === '/api/epever/metrics' ? Promise.reject(error) : notFound(),
+    );
 
     render(<Main />);
 
@@ -81,13 +132,34 @@ describe('dashboard', () => {
   });
 
   it('refetches when the refresh button is clicked', async () => {
-    mockedGet.mockResolvedValue({ data: METRICS });
-
     render(<Main />);
-    await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(mockedGet).toHaveBeenCalledWith('/api/epever/metrics'),
+    );
+    const before = callCount('/api/epever/metrics');
 
     screen.getByRole('button', { name: 'refresh metrics' }).click();
 
-    await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(callCount('/api/epever/metrics')).toBe(before + 1));
+  });
+
+  it('hides the battery panel when the voltgo controller is not running', async () => {
+    render(<Main />);
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo/metrics'));
+    expect(screen.queryByText('Battery Bank')).not.toBeInTheDocument();
+  });
+
+  it('shows the battery panel and refreshes it alongside the dashboard', async () => {
+    mockApi({ '/api/voltgo/metrics': VOLTGO_METRICS });
+
+    render(<Main />);
+    await waitFor(() => expect(screen.getByText('Battery Bank')).toBeInTheDocument());
+
+    const before = callCount('/api/voltgo/metrics');
+
+    screen.getByRole('button', { name: 'refresh metrics' }).click();
+
+    await waitFor(() => expect(callCount('/api/voltgo/metrics')).toBe(before + 1));
   });
 });

--- a/site/src/pages/main.tsx
+++ b/site/src/pages/main.tsx
@@ -6,24 +6,38 @@ import { Grid, Box, Alert, IconButton, Typography } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 
 import Metric from "../components/metric"
+import VoltgoBattery from "../components/voltgo-battery"
 import { CHARGING_STATUS_LABELS, type EpeverMetrics } from '../api/types';
 
 type MainState = {
   metrics: Partial<EpeverMetrics>;
   error: string | undefined;
   loading: boolean;
+  /** Incremented on every refresh, so child panels refetch alongside this one. */
+  refreshKey: number;
 };
 
 class Main extends React.Component<Record<string, never>, MainState> {
   constructor(props: Record<string, never>) {
     super(props);
 
-    this.state = { metrics: {}, error: undefined, loading: false };
+    this.state = { metrics: {}, error: undefined, loading: false, refreshKey: 0 };
 
     this.fetchMetrics = this.fetchMetrics.bind(this);
+    this.refresh = this.refresh.bind(this);
   }
 
   componentDidMount() {
+    this.fetchMetrics();
+  }
+
+  /**
+   * Refetches this page's metrics and bumps refreshKey so the panels that own
+   * their own fetches reload too. Mount does not bump it: those panels already
+   * fetch on mount, and bumping would make them fetch twice.
+   */
+  refresh() {
+    this.setState(state => ({ refreshKey: state.refreshKey + 1 }));
     this.fetchMetrics();
   }
 
@@ -107,9 +121,12 @@ class Main extends React.Component<Record<string, never>, MainState> {
             </Grid>
           </Grid>
 
+          {/* Battery bank via the voltgo BLE controller; renders nothing when it is disabled */}
+          <VoltgoBattery refreshKey={this.state.refreshKey} />
+
           <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
             <IconButton
-              onClick={this.fetchMetrics}
+              onClick={this.refresh}
               disabled={this.state.loading}
               sx={{
                 backgroundColor: 'white',


### PR DESCRIPTION
### What

Dashboard panel for the voltgo battery pack, plus a JSON 404 for unmatched /api routes so the panel can hide itself when the controller is disabled.

### Why

The voltgo controller has been collecting and publishing since #123, but nothing in the web UI showed it.

### Testing

make test-coverage (gate green, internal/app floor ratcheted 92 -> 93), golangci-lint (0 issues), site: npm run typecheck, npm run lint, vitest (47 passing)

Fixes #131
Part of #137