### PR TITLE
chore: Voltgo docs, example config, packaging notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Solar-controller is a Go-based service that collects metrics from solar power equipment (Epever) and publishes them via MQTT, Solace, AWS SNS, file logging, or Prometheus remote_write, with metrics also exposed via Prometheus scraping. It includes a React-based web UI for monitoring.
+Solar-controller is a Go-based service that collects metrics from solar power equipment — Epever charge controllers over Modbus RTU and Voltgo batteries over Bluetooth LE — and publishes them via MQTT, Solace, AWS SNS, file logging, or Prometheus remote_write, with metrics also exposed via Prometheus scraping. It includes a React-based web UI for monitoring.
 
 ## Project Navigation
 
 | Directory | What | When to read |
 |-----------|------|--------------|
 | `cmd/controller/` | Application entry point | Changing startup, flags, or controller wiring |
-| `internal/controllers/` | Hardware controller implementations (epever) | Adding controllers, modifying collection or publishing logic |
+| `internal/controllers/` | Hardware controller implementations | Adding controllers, modifying collection or publishing logic |
+| `internal/controllers/epever/` | Epever charge controller over Modbus RTU | Changing solar metric collection or device configuration |
+| `internal/controllers/voltgo/` | Voltgo battery over Bluetooth LE | Changing battery collection, cell metrics, or BLE connection handling |
 | `internal/publishers/` | Publisher factory, MultiPublisher, MessagePublisher interface | Adding a new publisher or changing fan-out behavior |
 | `internal/publishers/mqtt/` | MQTT publisher | Modifying MQTT publishing |
 | `internal/publishers/solace/` | Solace publisher | Modifying Solace publishing |
@@ -302,7 +304,7 @@ The release workflow:
 - RPM packages (.rpm) for RHEL/CentOS/Fedora systems
 - Multi-architecture Docker images pushed to registry
 
-**Note:** CGO is required for the Solace messaging library, so all builds must be done on native architecture runners or with appropriate cross-compilation toolchains.
+**Note:** CGO is required for the Solace messaging library, so all builds must be done on native architecture runners or with appropriate cross-compilation toolchains. The BLE stack does not add to that: `tinygo.org/x/bluetooth` talks to BlueZ over D-Bus in pure Go, so the ARM64 path is unchanged by voltgo. BLE is a runtime dependency on the target host, not a build-time one — the deb and rpm packages recommend `bluez` for it.
 
 ### Deployment
 
@@ -342,6 +344,10 @@ The Epever controller follows this structure:
 - **Collector**: Handles device communication and metric collection
 - **Configurer**: Manages device configuration
 - **PrometheusCollector**: Exposes metrics to Prometheus
+
+The Voltgo controller follows the same shape minus the Configurer - the battery
+is read-only over BLE - and adds a **BLEConnector**, which owns the connection
+so the Collector can be tested against a fake.
 
 Controllers are instantiated in `main.go:buildControllers()` and conditionally enabled based on configuration. Each controller has an `enabled` boolean field that must be set to `true` for the controller to start. If required config fields are missing (even when enabled is true), the controller returns an empty/disabled instance.
 
@@ -442,6 +448,22 @@ Epever controller publishes the following metrics (kebab-case naming):
 **Failure Metrics** (published when collection fails):
 - `collection-failure` (count) - Collection failure indicator (value is always 1, published when complete collection fails)
 
+Voltgo controller publishes the following metrics:
+
+- `battery-voltage` (volts) - Pack voltage
+- `battery-current` (amperes) - Pack current, positive charging, negative discharging
+- `battery-power` (watts) - Derived from voltage and current
+- `battery-soc` (percent) - State of charge
+- `battery-soh` (percent) - State of health
+- `battery-temp` (celsius) - Pack temperature
+- `cell-voltage-delta` (volts) - Spread between the highest and lowest cell
+- `collection-time` (seconds) - Time taken to collect metrics
+- `collection-failure` (count) - Published instead of the above when a cycle fails
+
+Per-cell voltages are deliberately not published - they would scale the topic
+space with the cell count. They are exposed on `/api/voltgo/metrics` and as the
+`voltgo_cell_voltage` Prometheus gauge, labelled by cell index.
+
 #### Wildcard Subscriptions
 
 MQTT/Solace subscribers can use wildcard patterns:
@@ -477,7 +499,7 @@ epever_battery_voltage{device_id="controller-123"}
 ```
 
 **Batching:**
-All 12 normal metrics from each successful collection cycle are batched into a single WriteRequest, reducing HTTP overhead and improving efficiency. When collection fails, a single `collection-failure` metric is published instead.
+Every metric from a successful collection cycle is batched into a single WriteRequest, reducing HTTP overhead and improving efficiency. When collection fails, a single `collection-failure` metric is published instead.
 
 ### Communication Protocols
 
@@ -486,6 +508,12 @@ All 12 normal metrics from each successful collection cycle are batched into a s
   - Retry attempts: 2 with 1-second delay between retries
   - Collection overlap prevention via mutex guard
   - 50ms delays between metric reads to prevent device lockups
+- **Voltgo**: Bluetooth LE GATT (via `lumberbarons/voltgo`, over `tinygo.org/x/bluetooth`)
+  - On Linux this is BlueZ driven over D-Bus, in pure Go - no cgo, so it adds nothing to the cross-build requirements
+  - The connection is opened lazily on the first collection, reused across cycles, and dropped on a read error so the next cycle reconnects
+  - Connect timeout 30s by default; a full cycle is bounded at 60 seconds to cover the connect plus the status reads
+  - Collection overlap prevention via mutex guard
+  - Static battery info is fetched once, on the first cycle that connects successfully
 
 ### Web Server
 
@@ -497,9 +525,13 @@ All 12 normal metrics from each successful collection cycle are batched into a s
   - `/api/epever/charging-parameters` - Charging parameters configuration (GET/PATCH)
   - `/api/epever/time` - Controller time (GET/PATCH)
   - `/api/epever/config` - Legacy configuration endpoint (GET/PATCH)
+  - `/api/voltgo/metrics` - JSON battery status including per-cell voltages
+  - `/api/voltgo/info` - Static battery info (chemistry, nominal voltage, capacity)
   - `/*` - Embedded React SPA (via `//go:embed site/build`)
-- **SPA Support**: NoRoute handler serves index.html for client-side routing (React Router)
+- **SPA Support**: NoRoute handler serves index.html for client-side routing (React Router), except under `/api`, where an unmatched route returns a JSON 404. A disabled controller registers no endpoints, so the frontend uses that 404 to hide its panel; answering with index.html would look like a successful response
 - **Namespace**: Each controller registers endpoints under `/api/{controllerName}` where the controller name matches the hardware type (e.g., "epever")
+
+Both voltgo endpoints return `204 No Content` until the first successful collection, so "enabled but nothing read yet" is distinguishable from "not configured".
 
 The React frontend is embedded into the binary at build time and served statically by Gin. The frontend build artifacts are copied from `site/build` to `internal/static/build` during the build process, where they're embedded using `//go:embed`.
 
@@ -551,9 +583,16 @@ solarController:
     enabled: true
     serialPort: /dev/ttyXRUSB0
     publishPeriod: 60
+  voltgo:
+    enabled: false
+    address: AA:BB:CC:DD:EE:FF  # BLE address of the battery
+    publishPeriod: 60
+    connectTimeout: 30s         # Optional (default: 30s)
 ```
 
-The controller can be explicitly enabled or disabled via the `enabled` boolean field. If `enabled: false`, the controller will not start regardless of other configuration. If `enabled: true` but required fields are missing (serialPort for epever), a warning will be logged and the controller will not start.
+A controller can be explicitly enabled or disabled via the `enabled` boolean field. If `enabled: false`, the controller will not start regardless of other configuration.
+
+The two controllers differ in how they treat a bad configuration. Epever warns and stays down when `serialPort` is missing; voltgo is validated in `config.Validate()`, so an enabled section without an `address`, or with a non-positive `publishPeriod` or an unparseable `connectTimeout`, fails startup outright. Keep that in mind when adding fields to either.
 
 **Global Configuration:**
 - `deviceId` (optional): Unique identifier for this device instance, used in publisher topics across all controllers. Defaults to `"controller-1"` if not specified.
@@ -563,6 +602,12 @@ The controller can be explicitly enabled or disabled via the `enabled` boolean f
 **Epever Controller Configuration:**
 - `serialPort` (required): Serial port path for Modbus RTU communication
 - `publishPeriod` (required): Collection interval in seconds
+
+**Voltgo Controller Configuration:**
+- `address` (required): BLE address of the battery, e.g. `AA:BB:CC:DD:EE:FF`
+- `publishPeriod` (required): Collection interval in seconds, must be positive
+- `connectTimeout` (optional): BLE connect timeout as a duration string (default: `30s`)
+- Requires BlueZ on the host; see the Bluetooth LE section of `README.md` for the D-Bus permissions the service needs and why Docker is not a suitable deployment for it
 
 **Message Publisher Configuration:**
 - Multiple publishers can be enabled simultaneously - metrics will be published to all enabled publishers

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # solar-controller
 
-A Go-based service that collects metrics from solar power equipment (Epever) and publishes them via multiple backends (MQTT, Solace, File, or Prometheus Remote Write). Metrics are also exposed via Prometheus scraping endpoint. It includes a React-based web UI for monitoring.
+A Go-based service that collects metrics from solar power equipment — Epever charge controllers over Modbus and Voltgo batteries over Bluetooth LE — and publishes them via multiple backends (MQTT, Solace, File, or Prometheus Remote Write). Metrics are also exposed via Prometheus scraping endpoint. It includes a React-based web UI for monitoring.
 
 ## Features
 
 - Modular controller architecture supporting multiple hardware types
+  - **Epever** - charge controller metrics and configuration over Modbus RTU
+  - **Voltgo** - battery pack metrics (SOC, health, per-cell voltages) over Bluetooth LE
 - Multiple publishing options:
   - **MQTT** - Lightweight message broker for home automation systems
   - **Solace** - Enterprise-grade messaging with Solace PubSub+
@@ -145,6 +147,10 @@ docker build -t solar-controller .
 docker run solar-controller -config /etc/solar-controller/config.yaml
 ```
 
+The container has no Bluetooth adapter and no host D-Bus, so the voltgo
+controller does not work in this deployment — see
+[Bluetooth LE (Voltgo)](#bluetooth-le-voltgo).
+
 ### Release
 
 The project uses GitHub Actions for multi-platform releases with native builds:
@@ -166,6 +172,12 @@ Releases include:
 - Debian packages (.deb)
 - RPM packages (.rpm)
 - Multi-architecture Docker images
+
+CGO is enabled for the Solace messaging library, which is why builds run on
+native runners. Bluetooth adds nothing to that: `tinygo.org/x/bluetooth` drives
+BlueZ over D-Bus in pure Go, so the ARM64 build path is unchanged. BlueZ is a
+runtime dependency of the host, not of the build — the deb and rpm packages
+list `bluez` as a recommendation, since only voltgo needs it.
 
 ## Configuration
 
@@ -229,6 +241,12 @@ solarController:
     enabled: true
     serialPort: /dev/ttyXRUSB0
     publishPeriod: 60
+
+  voltgo:
+    enabled: false
+    address: AA:BB:CC:DD:EE:FF  # BLE address of the battery
+    publishPeriod: 60
+    connectTimeout: 30s         # Optional (default: 30s)
 ```
 
 ### Configuration Details
@@ -240,9 +258,10 @@ solarController:
 - When `tls.certFile` and `tls.keyFile` are both set, the server serves HTTPS; otherwise it serves plain HTTP. A TLS-terminating reverse proxy (nginx, Caddy, Traefik) in front of the plain HTTP server is an equally good option.
 
 **Hardware Controllers:**
-- Each controller (e.g., epever) has an `enabled` boolean field
+- Each controller (epever, voltgo) has an `enabled` boolean field
 - Set `enabled: true` to activate the controller
-- If required fields are missing (serialPort for epever), a warning will be logged and the controller won't start
+- **epever** requires `serialPort` and `publishPeriod`. If `serialPort` is missing, a warning is logged and the controller won't start
+- **voltgo** requires `address` (the battery's BLE address) and a positive `publishPeriod`; `connectTimeout` is optional and defaults to `30s`. Unlike epever, an enabled voltgo section missing either required field fails startup with a configuration error rather than starting without the controller
 
 **Message Publishers:**
 - Multiple publishers can be enabled simultaneously — metrics are published to all enabled publishers (fan-out)
@@ -258,6 +277,67 @@ solarController:
 - **Remote Write**: Push to Prometheus-compatible endpoints with authentication and custom headers
 
 When a publisher is configured with credentials, use an encrypted transport scheme so they are protected in transit: `ssl://`, `tls://`, `mqtts://`, or `wss://` for MQTT, `tcps://` for Solace, and `https://` for Remote Write. Pairing credentials with a plaintext scheme (`mqtt://`, `tcp://`, `http://`) logs a startup warning.
+
+### Bluetooth LE (Voltgo)
+
+The voltgo controller talks to the battery over Bluetooth LE, which on Linux
+means talking to BlueZ over D-Bus. The host therefore needs:
+
+- **BlueZ installed and running** — `bluez` 5.48 or newer, with `bluetoothd`
+  active (`systemctl status bluetooth`). The deb and rpm packages recommend
+  `bluez`, so it is pulled in by default on Debian and Ubuntu; install it
+  explicitly if your package manager skips weak dependencies.
+- **A Bluetooth adapter** visible to BlueZ (`bluetoothctl list`).
+- **Permission to talk to `org.bluez`** for the user the service runs as (see
+  below).
+
+Find the battery's address with a scan:
+
+```bash
+bluetoothctl scan le      # note the address of the battery, e.g. AA:BB:CC:DD:EE:FF
+```
+
+Then set it as `voltgo.address`. Pairing is not required: the controller
+connects on its first collection, keeps the connection while it stays alive, and
+reconnects on the next cycle after a read error.
+
+#### Running as a service
+
+The packaged systemd unit runs as the unprivileged `solar-controller` user,
+which by default is not allowed to send D-Bus messages to `org.bluez`. Most
+distributions grant that to the `bluetooth` group, so add it with a drop-in:
+
+```bash
+sudo systemctl edit solar-controller
+```
+
+```ini
+[Service]
+SupplementaryGroups=bluetooth
+```
+
+This is not in the shipped unit because systemd refuses to start a service whose
+supplementary group does not exist, and `bluetooth` only exists once BlueZ is
+installed — an epever-only install would stop working.
+
+If the service still logs D-Bus permission errors, check that
+`/etc/dbus-1/system.d/bluetooth.conf` contains a policy for the group; some
+images ship without one:
+
+```xml
+<policy group="bluetooth">
+  <allow send_destination="org.bluez"/>
+</policy>
+```
+
+#### Docker
+
+BLE does not work in the standard Docker deployment: the container has neither
+the host's D-Bus system bus nor its Bluetooth adapter. Use the deb or rpm
+package with systemd on the host for voltgo, and keep Docker for epever-only or
+publisher-only deployments. Granting a container that access takes host D-Bus
+and privileged Bluetooth capabilities, which gives up much of the isolation the
+container was for.
 
 ### Debug Mode
 
@@ -339,6 +419,13 @@ Each controller follows the same structure:
 ### Communication Protocols
 
 - **Epever**: Modbus RTU over serial (via `lumberbarons/modbus`)
+- **Voltgo**: Bluetooth LE GATT (via `lumberbarons/voltgo`, which uses
+  `tinygo.org/x/bluetooth`). On Linux that is BlueZ driven over D-Bus, in pure
+  Go — no cgo and no extra toolchain, so the ARM64 cross-build is unaffected.
+  The connection is opened lazily on the first collection, reused across
+  cycles, and dropped on a read error so the next cycle reconnects. A full
+  cycle is bounded at 60 seconds, which covers the 30-second connect timeout
+  plus the status reads.
 
 #### Modbus Communication Reliability
 
@@ -363,6 +450,13 @@ These delays and timeouts ensure the Epever device has adequate time to process 
 #### Monitoring Endpoints
 - `GET /metrics` - Prometheus metrics export
 - `GET /api/epever/metrics` - JSON metrics for Epever controller (current status)
+- `GET /api/voltgo/metrics` - JSON metrics for the Voltgo battery, including per-cell voltages
+- `GET /api/voltgo/info` - Static battery information (chemistry, nominal voltage, capacity)
+
+A controller that is not running registers no endpoints, and unmatched `/api`
+routes return `404` with a JSON body. Both voltgo endpoints answer `204` until
+the first successful collection, which is what the web UI uses to tell "no
+battery configured" apart from "no reading yet".
 
 #### Configuration Endpoints
 - `GET /api/epever/battery-profile` - Get battery type and capacity
@@ -425,7 +519,38 @@ Example with `topicPrefix: "solar"` and `deviceId: "controller-123"`:
 solar/controller-123/epever/array-voltage
 solar/controller-123/epever/battery-soc
 solar/controller-123/epever/charging-power
+solar/controller-123/voltgo/battery-soh
+solar/controller-123/voltgo/cell-voltage-delta
 ```
+
+### Published Metrics
+
+Each controller publishes one message per metric per collection cycle:
+
+| Controller | Metric | Unit |
+|------------|--------|------|
+| epever | `array-voltage`, `battery-voltage` | volts |
+| epever | `array-current`, `charging-current` | amperes |
+| epever | `array-power`, `charging-power` | watts |
+| epever | `battery-soc` | percent |
+| epever | `battery-temp`, `device-temp` | celsius |
+| epever | `energy-generated-daily` | kilowatt-hours |
+| epever | `charging-status` | code |
+| epever | `collection-time` | seconds |
+| voltgo | `battery-voltage`, `cell-voltage-delta` | volts |
+| voltgo | `battery-current` (positive charging, negative discharging) | amperes |
+| voltgo | `battery-power` | watts |
+| voltgo | `battery-soc`, `battery-soh` | percent |
+| voltgo | `battery-temp` | celsius |
+| voltgo | `collection-time` | seconds |
+
+When a collection cycle fails, the controller publishes a single
+`collection-failure` metric (unit `count`, value `1`) instead.
+
+Per-cell voltages are deliberately not published: they would multiply the topic
+space by the cell count. They are available from `GET /api/voltgo/metrics`, from
+the web UI, and as the `voltgo_cell_voltage` Prometheus metric, labelled by
+cell.
 
 ### Message Payload
 
@@ -444,6 +569,7 @@ When using the RemoteWrite publisher, metrics are converted to Prometheus format
 - Metric names: `{controller}_{metric_name}` (snake_case)
 - Labels: `device_id`, `controller`, `unit`
 - Example: `epever_battery_voltage{device_id="controller-123",unit="volts"}`
+- Voltgo metrics follow the same rule: `voltgo_battery_soh{device_id="controller-123",unit="percent"}`
 
 All metrics from each collection cycle are batched into a single WriteRequest for efficiency.
 
@@ -466,7 +592,7 @@ See `examples/remotewrite/README.md` for details.
 ## Project Structure
 
 - `cmd/controller/` - Main application entry point
-- `internal/controllers/` - Hardware controller implementations (epever)
+- `internal/controllers/` - Hardware controller implementations (epever, voltgo)
 - `internal/publishers/mqtt/` - MQTT publishing functionality
 - `internal/publishers/solace/` - Solace publishing functionality
 - `internal/publishers/sns/` - AWS SNS publishing functionality

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -42,10 +42,18 @@ scripts:
   postinstall: package/postinstall.sh
   postremove: package/postremove.sh
 
+# bluez is a recommendation rather than a dependency: it is needed only by the
+# voltgo BLE controller, and an epever-only install has no use for it. The
+# service does not get access to org.bluez by installing it — see the Bluetooth
+# LE section of the README for the systemd drop-in that grants that.
 overrides:
   deb:
     depends:
       - systemd
+    recommends:
+      - bluez
   rpm:
     depends:
       - systemd
+    recommends:
+      - bluez

--- a/package/config.yaml
+++ b/package/config.yaml
@@ -5,3 +5,13 @@ solarController:
     enabled: true
     serialPort: /dev/ttyXRUSB0
     publishPeriod: 30
+
+  # Voltgo battery over Bluetooth LE. Needs bluez running, the battery's BLE
+  # address, and permission for the solar-controller user to talk to org.bluez
+  # (see the Bluetooth LE section of the README). An enabled section without an
+  # address fails startup, so this stays commented out until it is filled in.
+  # voltgo:
+  #   enabled: true
+  #   address: AA:BB:CC:DD:EE:FF
+  #   publishPeriod: 60
+  #   connectTimeout: 30s


### PR DESCRIPTION
### What

README and CLAUDE.md coverage of the voltgo BLE controller, a commented voltgo block in the packaged config, and bluez as a deb/rpm recommendation.

### Why

The voltgo controller shipped across #120-#123 with no user-facing documentation: nothing said what to configure, what it publishes, or that BLE needs BlueZ and D-Bus permissions the packaged service does not have by default.

### Testing

go build ./... and go test ./... pass; built a test .deb and .rpm with nfpm and confirmed Recommends: bluez in both; built internal/controllers/voltgo with CGO_ENABLED=0 GOOS=linux GOARCH=arm64 to back the cross-build claim.

Fixes #132
Part of #137