### PR TITLE
fix: Tautological assertions on state the code under test cannot modify

### DIFF
--- a/internal/publishers/factory_test.go
+++ b/internal/publishers/factory_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/lumberbarons/solar-controller/internal/publishers/solace"
 )
 
+// Compile-time check that NoOpPublisher satisfies MessagePublisher.
+var _ publish.MessagePublisher = (*publish.NoOpPublisher)(nil)
+
 func TestNewPublisher(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -214,16 +217,12 @@ func TestNewPublisher(t *testing.T) {
 	}
 }
 
-func TestNoOpPublisher(t *testing.T) {
-	// Verify NoOpPublisher satisfies MessagePublisher interface at compile time
+// TestNoOpPublisher_MethodsDoNotPanic is a smoke test: the no-op publisher's
+// methods discard their arguments, so there is no observable state to assert
+// on. Reaching the end of the test without panicking is the whole check.
+func TestNoOpPublisher_MethodsDoNotPanic(_ *testing.T) {
 	var pub publish.MessagePublisher = &publish.NoOpPublisher{}
 
-	// Should not panic when used as MessagePublisher
 	pub.Publish("test", "payload")
 	pub.Close()
-
-	// Verify the concrete type is preserved after operations
-	if _, ok := pub.(*publish.NoOpPublisher); !ok {
-		t.Error("Expected publisher to remain a *publish.NoOpPublisher")
-	}
 }

--- a/internal/publishers/multi_publisher_test.go
+++ b/internal/publishers/multi_publisher_test.go
@@ -144,7 +144,7 @@ func TestMultiPublisher_Close_ClosesAllPublishers(t *testing.T) {
 	}
 }
 
-func TestMultiPublisher_EmptyPublishers(t *testing.T) {
+func TestMultiPublisher_EmptyPublishers(_ *testing.T) {
 	// Arrange
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
@@ -152,14 +152,10 @@ func TestMultiPublisher_EmptyPublishers(t *testing.T) {
 	publishers := []publish.MessagePublisher{}
 	multiPublisher := NewMultiPublisher(publishers, logger)
 
-	// Act - should not panic with zero publishers
+	// Act - reaching the end without panicking is the assertion; a
+	// MultiPublisher wrapping no publishers has no observable side effects.
 	multiPublisher.Publish("device-1/epever/test", `{"value":1}`)
 	multiPublisher.Close()
-
-	// Verify the empty publisher list was not modified
-	if len(publishers) != 0 {
-		t.Error("Expected empty publishers slice to remain empty")
-	}
 }
 
 func TestMultiPublisher_SinglePublisher(t *testing.T) {

--- a/internal/publishers/sns/publisher_test.go
+++ b/internal/publishers/sns/publisher_test.go
@@ -109,32 +109,27 @@ func TestResolveTopicPrefix(t *testing.T) {
 	}
 }
 
-func TestPublish_DisabledPublisher(t *testing.T) {
+// TestPublish_DisabledPublisherDoesNotPanic is a smoke test: a disabled
+// publisher has a nil client, so Publish must return early rather than
+// dereference it. Reaching the end without panicking is the assertion.
+func TestPublish_DisabledPublisherDoesNotPanic(_ *testing.T) {
 	pub := &Publisher{
 		client:      nil,
 		topicPrefix: "",
 	}
 
-	// Should not panic and client should remain nil (no side effects)
 	pub.Publish("test/topic", "test payload")
-
-	if pub.client != nil {
-		t.Error("Expected client to remain nil after publishing to disabled publisher")
-	}
 }
 
-func TestClose_DisabledPublisher(t *testing.T) {
+// TestClose_DisabledPublisherDoesNotPanic is the Close counterpart of
+// TestPublish_DisabledPublisherDoesNotPanic.
+func TestClose_DisabledPublisherDoesNotPanic(_ *testing.T) {
 	pub := &Publisher{
 		client:      nil,
 		topicPrefix: "",
 	}
 
-	// Should not panic and client should remain nil (no side effects)
 	pub.Close()
-
-	if pub.client != nil {
-		t.Error("Expected client to remain nil after closing disabled publisher")
-	}
 }
 
 // Note: Full integration tests with mocked SNS clients would require extensive

--- a/internal/publishers/solace/publisher_test.go
+++ b/internal/publishers/solace/publisher_test.go
@@ -114,34 +114,29 @@ func TestResolveTopicPrefix(t *testing.T) {
 	}
 }
 
-func TestPublish_DisabledPublisher(t *testing.T) {
+// TestPublish_DisabledPublisherDoesNotPanic is a smoke test: a disabled
+// publisher has nil messaging fields, so Publish must return early rather than
+// dereference them. Reaching the end without panicking is the assertion.
+func TestPublish_DisabledPublisherDoesNotPanic(_ *testing.T) {
 	pub := &Publisher{
 		publisher:        nil,
 		messagingService: nil,
 		topicPrefix:      "",
 	}
 
-	// Should not panic and fields should remain nil (no side effects)
 	pub.Publish("test/topic", "test payload")
-
-	if pub.publisher != nil {
-		t.Error("Expected publisher to remain nil after publishing to disabled publisher")
-	}
 }
 
-func TestClose_DisabledPublisher(t *testing.T) {
+// TestClose_DisabledPublisherDoesNotPanic is the Close counterpart of
+// TestPublish_DisabledPublisherDoesNotPanic.
+func TestClose_DisabledPublisherDoesNotPanic(_ *testing.T) {
 	pub := &Publisher{
 		publisher:        nil,
 		messagingService: nil,
 		topicPrefix:      "",
 	}
 
-	// Should not panic and fields should remain nil (no side effects)
 	pub.Close()
-
-	if pub.publisher != nil {
-		t.Error("Expected publisher to remain nil after closing disabled publisher")
-	}
 }
 
 func TestServicePropertyMap(t *testing.T) {


### PR DESCRIPTION
### What

Delete the tautological assertions in all four files; keep the `Publish`/`Close` calls as explicit no-panic smoke tests with intent stated in the name or a comment; add a package-level `var _ publish.MessagePublisher = (*publish.NoOpPublisher)(nil)` for interface conformance.

### Why

Four publisher test files assert conditions no production change can fail: `factory_test.go` type-asserts an interface still holds a freshly constructed `*NoOpPublisher` (interfaces cannot change dynamic type from method calls); `multi_publisher_test.go` asserts the test-local slice length was not modified (`MultiPublisher` gets a copy of the slice header); the SNS and Solace disabled-publisher tests assert client/publisher fields that neither `Publish` nor `Close` ever assigns and which the tests themselves initialized.

The assertions and comments mislead readers into believing an invariant is verified when the only real value is an implicit no-panic check.

### Testing

Structural change only — no behaviour changed, so no new tests. Verified with `go test ./...` (all packages pass), `golangci-lint run ./...` (0 issues), and `make test-coverage` (every package at or above its floor; `internal/publishers` 90.7%, total 66.7%). The two `Done when` items were checked against the diff by grep: no assertion on test-constructed state remains in the four files, and the conformance check is now the package-level `var _ publish.MessagePublisher = (*publish.NoOpPublisher)(nil)` in `factory_test.go`.

Fixes #117