### PR TITLE
fix: /api/info verified by substring matching with colliding fixtures

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,12 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// getTestVersionInfo returns version info for testing
+// getTestVersionInfo returns version info for testing. No value is a substring
+// of another, so an assertion satisfied by the wrong field cannot pass.
 func getTestVersionInfo() VersionInfo {
 	return VersionInfo{
-		Version:   "test",
-		BuildTime: "2025-01-01T00:00:00Z",
-		GitCommit: "test123",
+		Version:   "v-ver",
+		BuildTime: "b-time",
+		GitCommit: "g-commit",
 	}
 }
 
@@ -101,9 +103,19 @@ func TestApplication_InfoEndpoint(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
-	assert.Contains(t, w.Body.String(), versionInfo.Version)
-	assert.Contains(t, w.Body.String(), versionInfo.BuildTime)
-	assert.Contains(t, w.Body.String(), versionInfo.GitCommit)
+
+	// Decode into a map rather than VersionInfo: unmarshalling into the struct
+	// would rename the keys symmetrically with the handler, so a renamed json
+	// tag would still round-trip. Comparing the decoded map to an expected map
+	// fails on a wrong value, a missing field, or a renamed key.
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+
+	assert.Equal(t, map[string]string{
+		"version":   versionInfo.Version,
+		"buildTime": versionInfo.BuildTime,
+		"gitCommit": versionInfo.GitCommit,
+	}, got)
 }
 
 func TestApplication_Close(t *testing.T) {


### PR DESCRIPTION
### What

Unmarshal the `/api/info` body into a `VersionInfo` (or `map[string]string`) and assert field-by-field equality against the fixture, using collision-free fixture values in `getTestVersionInfo` (e.g. `Version` `v-ver`, `GitCommit` `g-commit`, `BuildTime` `b-time`).

### Why

`TestApplication_InfoEndpoint` asserts `Contains(body, ...)` for `Version='test'` and `GitCommit='test123'` — but `test` is a substring of `test123`, so the Version assertion is satisfied by the GitCommit value alone, and the JSON key names (`version`, `buildTime`, `gitCommit`) are never checked at all. Dropping the `Version` field from the response entirely, or renaming any JSON key, would still pass. The test's primary contract — the info endpoint returns version metadata under the documented keys — is not actually verified.

### Testing

Rewrote `TestApplication_InfoEndpoint` in `internal/app/app_test.go` to decode the body and compare it field-by-field. Proved the new assertions are falsifiable with three temporary mutations of `internal/app/app.go`, each of which the old `Contains` test would have passed: dropping the `version` field (`json:"-"`), renaming the key to `ver`, and returning a wrong `gitCommit` value — the test failed on all three, and the source was restored. Full gate: `go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues), and `make test-coverage` (exit 0, `internal/app` 93.0% against a 93% floor).

Fixes #124