### PR TITLE
chore: upgrade voltgo to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-co-op/gocron v1.37.0
 	github.com/klauspost/compress v1.19.1
 	github.com/lumberbarons/modbus v0.5.0
-	github.com/lumberbarons/voltgo v0.2.0
+	github.com/lumberbarons/voltgo v0.2.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/prometheus v0.313.1
 	github.com/sirupsen/logrus v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/lufia/plan9stats v0.0.0-20240226150601-1dcf7310316a h1:3Bm7EwfUQUvhNe
 github.com/lufia/plan9stats v0.0.0-20240226150601-1dcf7310316a/go.mod h1:ilwx/Dta8jXAgpFYFvSWEMwxmbWXyiUHkd5FwyKhb5k=
 github.com/lumberbarons/modbus v0.5.0 h1:6QALe5yY8Ba7gi2OR2QrEDScNkp97uARCOS1QzTz2W4=
 github.com/lumberbarons/modbus v0.5.0/go.mod h1:siOveg104gQ0JeWOU5YJXe6ZOvoYkIs+IEWy64RmuwE=
-github.com/lumberbarons/voltgo v0.2.0 h1:2vYTiZpMjeCncFm869GnD6TYCc/OBgBc5hqGhnaeGjk=
-github.com/lumberbarons/voltgo v0.2.0/go.mod h1:Y5DXTvyLDVHVZEWgIgopRMGLGa/2CUotgyH7DTyztAE=
+github.com/lumberbarons/voltgo v0.2.1 h1:zT0gBgDhEyP6jovymLzZoxS/D5BRTUiFVrl5H+VRo18=
+github.com/lumberbarons/voltgo v0.2.1/go.mod h1:lwaroJWtUzWc5RQFgkyD3Z9EBSmjCzNFbGE1Pw1Dk7U=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
## What

Bumps `github.com/lumberbarons/voltgo` from v0.2.0 to v0.2.1.

## Why

v0.2.1 fixes BLE connects on Linux/BlueZ that previously failed with
`le-connection-abort-by-local` on **every** attempt — the exact path the voltgo
controller takes on the Raspberry Pi deployment target. Upstream changes:

- Service discovery now follows the dial with nothing in between, so the BMS
  does not drop a link whose ATT MTU negotiation is slow to arrive
- A link the peer accepts and then aborts is retried rather than surfaced on the
  first failure
- A retry waits for BlueZ to report the aborted link torn down, instead of
  sleeping a fixed 500ms that could race or overshoot the teardown
- The retry budget rises from six dials to twelve, covering the thin tail of a
  distribution measured over 120 connects against real hardware

## Testing

- `go build ./...` and `go vet ./...` clean
- `make test-coverage` passes; every per-package floor still clears
  (`internal/controllers/voltgo` 81.2% vs 81% floor, total 66.7% vs 62%)
- No API changes — `go.mod` and `go.sum` are the only files in the diff
- Verified on the real battery on the Pi; see the PR thread for the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)
