### PR TITLE
feat: Support multiple Voltgo batteries across config, backend, and web UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Solar-controller is a Go-based service that collects metrics from solar power eq
 | `cmd/controller/` | Application entry point | Changing startup, flags, or controller wiring |
 | `internal/controllers/` | Hardware controller implementations | Adding controllers, modifying collection or publishing logic |
 | `internal/controllers/epever/` | Epever charge controller over Modbus RTU | Changing solar metric collection or device configuration |
-| `internal/controllers/voltgo/` | Voltgo battery over Bluetooth LE | Changing battery collection, cell metrics, or BLE connection handling |
+| `internal/controllers/voltgo/` | Voltgo batteries over Bluetooth LE | Changing battery collection, cell metrics, or BLE connection handling |
 | `internal/publishers/` | Publisher factory, MultiPublisher, MessagePublisher interface | Adding a new publisher or changing fan-out behavior |
 | `internal/publishers/mqtt/` | MQTT publisher | Modifying MQTT publishing |
 | `internal/publishers/solace/` | Solace publisher | Modifying Solace publishing |
@@ -349,6 +349,15 @@ The Voltgo controller follows the same shape minus the Configurer - the battery
 is read-only over BLE - and adds a **BLEConnector**, which owns the connection
 so the Collector can be tested against a fake.
 
+Voltgo is one controller driving *N* batteries, not one controller per battery.
+Each battery gets a **batteryRunner** (`battery.go`) holding its own Collector
+and cached status; the Controller owns the schedule, the routes, the shared
+Prometheus collector, and the shared BLE adapter. That split exists because the
+three things a second controller would duplicate are all process-wide: Gin
+panics on a duplicate route, promauto panics on a duplicate registration, and
+the host has one BLE adapter. Adding per-battery state means touching
+`batteryRunner`; adding anything registered once means touching `Controller`.
+
 Controllers are instantiated in `main.go:buildControllers()` and conditionally enabled based on configuration. Each controller has an `enabled` boolean field that must be set to `true` for the controller to start. If required config fields are missing (even when enabled is true), the controller returns an empty/disabled instance.
 
 ### Data Flow
@@ -460,9 +469,26 @@ Voltgo controller publishes the following metrics:
 - `collection-time` (seconds) - Time taken to collect metrics
 - `collection-failure` (count) - Published instead of the above when a cycle fails
 
+Voltgo topics carry an extra battery segment, because one controller drives
+several packs:
+
+```
+{topicPrefix}/{deviceId}/voltgo/{batteryId}/{metric-name}
+```
+
+Keeping the id as its own segment rather than folding it into the metric name
+lets a subscriber wildcard either way: `solar/+/voltgo/+/battery-soc` across
+every battery, `solar/+/voltgo/bank-a/#` across one battery's metrics. The
+RemoteWrite publisher accepts both the 3-segment and 4-segment forms and turns
+the battery segment into a `battery` label, so a remote-written series matches
+the scraped one.
+
 Per-cell voltages are deliberately not published - they would scale the topic
-space with the cell count. They are exposed on `/api/voltgo/metrics` and as the
-`voltgo_cell_voltage` Prometheus gauge, labelled by cell index.
+space with the cell count. They are exposed on `/api/voltgo/{id}/metrics` and as
+the `voltgo_cell_voltage` Prometheus gauge, labelled by `battery` and cell
+index. Every `voltgo_*` series carries the `battery` label, including in a
+single-battery deployment, so a query does not have to change when a second
+battery is added.
 
 #### Wildcard Subscriptions
 
@@ -511,8 +537,10 @@ Every metric from a successful collection cycle is batched into a single WriteRe
 - **Voltgo**: Bluetooth LE GATT (via `lumberbarons/voltgo`, over `tinygo.org/x/bluetooth`)
   - On Linux this is BlueZ driven over D-Bus, in pure Go - no cgo, so it adds nothing to the cross-build requirements
   - The connection is opened lazily on the first collection, reused across cycles, and dropped on a read error so the next cycle reconnects
-  - Connect timeout 30s by default; a full cycle is bounded at 60 seconds to cover the connect plus the status reads
-  - Collection overlap prevention via mutex guard
+  - Connect timeout 30s by default; each battery in a cycle gets its own 60-second budget to cover the connect plus the status reads
+  - Batteries are collected **sequentially**, not concurrently: the host has one BLE adapter, BlueZ caps concurrent links, and overlapping connects provoke the `le-connection-abort-by-local` failures voltgo v0.2.1 fixed. `publishPeriod` therefore has to cover the sum of the per-battery times (~9s cold, well under 1s warm)
+  - A battery that fails to connect publishes its own `collection-failure` and does not stop the rest of the cycle
+  - Collection overlap prevention via mutex guard, across the whole cycle
   - Static battery info is fetched once, on the first cycle that connects successfully
 
 ### Web Server
@@ -525,13 +553,14 @@ Every metric from a successful collection cycle is batched into a single WriteRe
   - `/api/epever/charging-parameters` - Charging parameters configuration (GET/PATCH)
   - `/api/epever/time` - Controller time (GET/PATCH)
   - `/api/epever/config` - Legacy configuration endpoint (GET/PATCH)
-  - `/api/voltgo/metrics` - JSON battery status including per-cell voltages
-  - `/api/voltgo/info` - Static battery info (chemistry, nominal voltage, capacity)
+  - `/api/voltgo` - The configured batteries, as `{"batteries": [{"id", "address"}]}`
+  - `/api/voltgo/{id}/metrics` - JSON battery status including per-cell voltages
+  - `/api/voltgo/{id}/info` - Static battery info (chemistry, nominal voltage, capacity)
   - `/*` - Embedded React SPA (via `//go:embed site/build`)
 - **SPA Support**: NoRoute handler serves index.html for client-side routing (React Router), except under `/api`, where an unmatched route returns a JSON 404. A disabled controller registers no endpoints, so the frontend uses that 404 to hide its panel; answering with index.html would look like a successful response
 - **Namespace**: Each controller registers endpoints under `/api/{controllerName}` where the controller name matches the hardware type (e.g., "epever")
 
-Both voltgo endpoints return `204 No Content` until the first successful collection, so "enabled but nothing read yet" is distinguishable from "not configured".
+Both per-battery voltgo endpoints return `204 No Content` until that battery's first successful collection, so "enabled but nothing read yet" is distinguishable from "not configured"; an unknown battery id returns `404`. The index answers `200` whenever the controller is running, and is how the frontend discovers how many panels to render - a `404` there is what hides the panel entirely.
 
 The React frontend is embedded into the binary at build time and served statically by Gin. The frontend build artifacts are copied from `site/build` to `internal/static/build` during the build process, where they're embedded using `//go:embed`.
 
@@ -585,14 +614,18 @@ solarController:
     publishPeriod: 60
   voltgo:
     enabled: false
-    address: AA:BB:CC:DD:EE:FF  # BLE address of the battery
-    publishPeriod: 60
-    connectTimeout: 30s         # Optional (default: 30s)
+    publishPeriod: 60           # Must cover one connect-and-read per battery
+    connectTimeout: 30s         # Optional (default: 30s), applied per battery
+    batteries:
+      - id: bank-a              # Optional; defaults to the address, lowercased with dashes
+        address: A4:C1:37:43:A4:33
+      - id: bank-b
+        address: A4:C1:37:43:A4:42
 ```
 
 A controller can be explicitly enabled or disabled via the `enabled` boolean field. If `enabled: false`, the controller will not start regardless of other configuration.
 
-The two controllers differ in how they treat a bad configuration. Epever warns and stays down when `serialPort` is missing; voltgo is validated in `config.Validate()`, so an enabled section without an `address`, or with a non-positive `publishPeriod` or an unparseable `connectTimeout`, fails startup outright. Keep that in mind when adding fields to either.
+The two controllers differ in how they treat a bad configuration. Epever warns and stays down when `serialPort` is missing; voltgo is validated in `config.Validate()`, which delegates to `voltgo.Configuration.Validate()`, so an enabled section with no battery, a battery without an address, a duplicate id or address, a malformed id, a non-positive `publishPeriod`, or an unparseable `connectTimeout` fails startup outright. Keep that in mind when adding fields to either.
 
 **Global Configuration:**
 - `deviceId` (optional): Unique identifier for this device instance, used in publisher topics across all controllers. Defaults to `"controller-1"` if not specified.
@@ -604,9 +637,17 @@ The two controllers differ in how they treat a bad configuration. Epever warns a
 - `publishPeriod` (required): Collection interval in seconds
 
 **Voltgo Controller Configuration:**
-- `address` (required): BLE address of the battery, e.g. `AA:BB:CC:DD:EE:FF`
+- `batteries` (required): the batteries to collect from, each with an `address` and an optional `id`
+- `address` (deprecated): a single battery's BLE address, kept working for existing configs. Setting it alongside `batteries` is an error rather than a merge
 - `publishPeriod` (required): Collection interval in seconds, must be positive
-- `connectTimeout` (optional): BLE connect timeout as a duration string (default: `30s`)
+- `connectTimeout` (optional): BLE connect timeout as a duration string (default: `30s`), applied per battery
+
+A battery's `id` is used verbatim in its routes, its Prometheus `battery` label,
+and its publisher topic segment, so it is validated against
+`^[a-z0-9][a-z0-9-]*$` - a slash would split a route and a topic, `+`/`#` would
+collide with MQTT wildcards. Omitted, it is derived from the address
+(`A4:C1:37:43:A4:33` -> `a4-c1-37-43-a4-33`). Duplicate ids and duplicate
+addresses (compared case-insensitively) both fail startup.
 - Requires BlueZ on the host; see the Bluetooth LE section of `README.md` for the D-Bus permissions the service needs and why Docker is not a suitable deployment for it
 
 **Message Publisher Configuration:**

--- a/README.md
+++ b/README.md
@@ -244,9 +244,13 @@ solarController:
 
   voltgo:
     enabled: false
-    address: AA:BB:CC:DD:EE:FF  # BLE address of the battery
-    publishPeriod: 60
-    connectTimeout: 30s         # Optional (default: 30s)
+    publishPeriod: 60           # Covers one connect-and-read per battery
+    connectTimeout: 30s         # Optional (default: 30s), applied per battery
+    batteries:
+      - id: bank-a              # Optional; defaults to the address, lowercased with dashes
+        address: A4:C1:37:43:A4:33
+      - id: bank-b
+        address: A4:C1:37:43:A4:42
 ```
 
 ### Configuration Details
@@ -261,7 +265,56 @@ solarController:
 - Each controller (epever, voltgo) has an `enabled` boolean field
 - Set `enabled: true` to activate the controller
 - **epever** requires `serialPort` and `publishPeriod`. If `serialPort` is missing, a warning is logged and the controller won't start
-- **voltgo** requires `address` (the battery's BLE address) and a positive `publishPeriod`; `connectTimeout` is optional and defaults to `30s`. Unlike epever, an enabled voltgo section missing either required field fails startup with a configuration error rather than starting without the controller
+- **voltgo** requires at least one battery and a positive `publishPeriod`; `connectTimeout` is optional and defaults to `30s`. Unlike epever, an enabled voltgo section missing a required field fails startup with a configuration error rather than starting without the controller
+
+#### Multiple Voltgo batteries
+
+`voltgo.batteries` is a list, so a bank of several packs is collected by one
+service. Each entry takes an `address` and an optional `id`.
+
+The `id` is the battery's name in three places at once — its HTTP routes
+(`/api/voltgo/{id}/metrics`), its Prometheus `battery` label, and its publisher
+topic segment — so it is constrained to lowercase letters, digits, and dashes.
+A slash would split a route and a topic in two; a `+` or `#` would collide with
+MQTT wildcards. Omit it and it is derived from the address:
+`A4:C1:37:43:A4:33` becomes `a4-c1-37-43-a4-33`, which works but reads poorly
+on a dashboard, so name them.
+
+Startup rejects two batteries sharing an `id` (they would collapse onto one
+route, one series, and one topic) and two sharing an `address`, compared
+case-insensitively (they would fight over one BLE connection).
+
+Batteries are collected **one after another**, not concurrently: the host has a
+single BLE adapter, BlueZ caps concurrent links, and overlapping connects
+provoke the `le-connection-abort-by-local` failures that voltgo v0.2.1 fixed. A
+cold connect costs roughly 9 seconds and a warm one well under a second, so size
+`publishPeriod` to cover a connect-and-read for every battery — a cycle still
+running when the next tick arrives logs a warning and skips that tick. One
+battery failing to connect does not stop the rest of the cycle: it publishes its
+own `collection-failure` and the remaining batteries are collected normally.
+
+**Migrating from a single battery.** The old singular form still works:
+
+```yaml
+  voltgo:
+    enabled: true
+    address: AA:BB:CC:DD:EE:FF   # Deprecated: use batteries
+    publishPeriod: 60
+```
+
+It is treated as a one-entry list whose `id` is derived from the address.
+Setting both `address` and `batteries` is an error rather than a merge, so the
+configuration can never mean two things at once.
+
+Two things do change for an existing deployment, whichever form is used:
+
+- Publisher topics gain a battery segment: `…/voltgo/battery-soc` becomes
+  `…/voltgo/{id}/battery-soc`. Subscribers matching the old path need updating.
+- Prometheus series gain a `battery` label. Existing queries keep returning
+  data, but a query that assumed one series per metric now sees one per battery.
+
+Moving to `batteries` with an explicit `id` at the same time avoids having the
+derived id baked into topics and dashboards.
 
 **Message Publishers:**
 - Multiple publishers can be enabled simultaneously — metrics are published to all enabled publishers (fan-out)
@@ -297,7 +350,9 @@ Find the battery's address with a scan:
 bluetoothctl scan le      # note the address of the battery, e.g. AA:BB:CC:DD:EE:FF
 ```
 
-Then set it as `voltgo.address`. Pairing is not required: the controller
+Then set it as a battery's `address` under `voltgo.batteries`. Note that a
+battery only appears while it is advertising, so a bank of several packs may
+need more than one scan to find them all. Pairing is not required: the controller
 connects on its first collection, keeps the connection while it stays alive, and
 reconnects on the next cycle after a read error.
 
@@ -450,13 +505,17 @@ These delays and timeouts ensure the Epever device has adequate time to process 
 #### Monitoring Endpoints
 - `GET /metrics` - Prometheus metrics export
 - `GET /api/epever/metrics` - JSON metrics for Epever controller (current status)
-- `GET /api/voltgo/metrics` - JSON metrics for the Voltgo battery, including per-cell voltages
-- `GET /api/voltgo/info` - Static battery information (chemistry, nominal voltage, capacity)
+- `GET /api/voltgo` - The configured batteries, as `{"batteries": [{"id": ..., "address": ...}]}`
+- `GET /api/voltgo/{id}/metrics` - JSON metrics for one battery, including per-cell voltages
+- `GET /api/voltgo/{id}/info` - Static battery information (chemistry, nominal voltage, capacity)
 
 A controller that is not running registers no endpoints, and unmatched `/api`
-routes return `404` with a JSON body. Both voltgo endpoints answer `204` until
-the first successful collection, which is what the web UI uses to tell "no
-battery configured" apart from "no reading yet".
+routes return `404` with a JSON body. The web UI reads the index first: a `404`
+there means no voltgo controller exists and the panel is hidden entirely, while
+the list it returns is how the UI knows how many panels to render. An unknown
+battery id under it also returns `404`. Both per-battery endpoints answer `204`
+until that battery's first successful collection, which distinguishes "not
+reporting yet" from "not configured".
 
 #### Configuration Endpoints
 - `GET /api/epever/battery-profile` - Get battery type and capacity
@@ -519,9 +578,21 @@ Example with `topicPrefix: "solar"` and `deviceId: "controller-123"`:
 solar/controller-123/epever/array-voltage
 solar/controller-123/epever/battery-soc
 solar/controller-123/epever/charging-power
-solar/controller-123/voltgo/battery-soh
-solar/controller-123/voltgo/cell-voltage-delta
+solar/controller-123/voltgo/bank-a/battery-soh
+solar/controller-123/voltgo/bank-a/cell-voltage-delta
+solar/controller-123/voltgo/bank-b/battery-soh
 ```
+
+Voltgo carries an extra `{batteryId}` segment, because one service collects a
+bank of several packs:
+```
+{topicPrefix}/{deviceId}/voltgo/{batteryId}/{metric-name}
+```
+
+Keeping the id as its own segment rather than folding it into the metric name
+means a subscriber can wildcard either way: `solar/+/voltgo/+/battery-soc` for
+one metric across every battery, `solar/+/voltgo/bank-a/#` for every metric of
+one battery.
 
 ### Published Metrics
 
@@ -548,9 +619,13 @@ When a collection cycle fails, the controller publishes a single
 `collection-failure` metric (unit `count`, value `1`) instead.
 
 Per-cell voltages are deliberately not published: they would multiply the topic
-space by the cell count. They are available from `GET /api/voltgo/metrics`, from
-the web UI, and as the `voltgo_cell_voltage` Prometheus metric, labelled by
-cell.
+space by the cell count. They are available from `GET /api/voltgo/{id}/metrics`,
+from the web UI, and as the `voltgo_cell_voltage` Prometheus metric, labelled by
+`battery` and `cell`.
+
+Every `voltgo_*` Prometheus series carries a `battery` label holding the
+configured id, including when only one battery is configured, so a query written
+for one pack keeps working when a second is added.
 
 ### Message Payload
 
@@ -569,7 +644,7 @@ When using the RemoteWrite publisher, metrics are converted to Prometheus format
 - Metric names: `{controller}_{metric_name}` (snake_case)
 - Labels: `device_id`, `controller`, `unit`
 - Example: `epever_battery_voltage{device_id="controller-123",unit="volts"}`
-- Voltgo metrics follow the same rule: `voltgo_battery_soh{device_id="controller-123",unit="percent"}`
+- Voltgo metrics follow the same rule and add a `battery` label from the topic's battery segment: `voltgo_battery_soh{device_id="controller-123",battery="bank-a",unit="percent"}`. The battery is a label rather than part of the metric name, so a remote-written series matches the one the `/metrics` scrape endpoint exposes for the same reading.
 
 All metrics from each collection cycle are batched into a single WriteRequest for efficiency.
 

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -66,7 +66,14 @@
     "GET /api/epever/time": [
       "time"
     ],
-    "GET /api/voltgo/metrics": [
+    "GET /api/voltgo": [
+      "batteries"
+    ],
+    "GET /api/voltgo#batteries[]": [
+      "address",
+      "id"
+    ],
+    "GET /api/voltgo/{id}/metrics": [
       "cellCount",
       "cells",
       "collectionTime",
@@ -78,11 +85,11 @@
       "timestamp",
       "voltage"
     ],
-    "GET /api/voltgo/metrics#cells[]": [
+    "GET /api/voltgo/{id}/metrics#cells[]": [
       "index",
       "voltage"
     ],
-    "GET /api/voltgo/info": [
+    "GET /api/voltgo/{id}/info": [
       "capacityAh",
       "chemistry",
       "deviceStrings",

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -211,7 +211,7 @@ func TestApplication_UnmatchedAPIRouteReturnsJSON404(t *testing.T) {
 	require.NoError(t, err)
 	defer app.Close()
 
-	for _, path := range []string{"/api/voltgo/metrics", "/api/epever/metrics", "/api/nonsense"} {
+	for _, path := range []string{"/api/voltgo", "/api/voltgo/bank-a/metrics", "/api/epever/metrics", "/api/nonsense"} {
 		t.Run(path, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", path, nil)

--- a/internal/app/wiring_test.go
+++ b/internal/app/wiring_test.go
@@ -275,10 +275,10 @@ func TestDefaultFactories_VoltgoNotStartedWithoutAddress(t *testing.T) {
 
 			assert.Empty(t, app.controllers)
 
-			assert.NotContains(t, registeredPaths(app), "/api/voltgo/metrics",
-				"voltgo endpoints were registered for a controller that never started")
-			assert.NotContains(t, registeredPaths(app), "/api/voltgo/info",
-				"voltgo endpoints were registered for a controller that never started")
+			for _, path := range []string{"/api/voltgo", "/api/voltgo/:id/metrics", "/api/voltgo/:id/info"} {
+				assert.NotContains(t, registeredPaths(app), path,
+					"voltgo endpoints were registered for a controller that never started")
+			}
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,13 +168,21 @@ func (c *Config) Validate() error {
 
 	// Validate Voltgo configuration if enabled
 	if c.SolarController.Voltgo.Enabled {
-		if c.SolarController.Voltgo.Address == "" {
+		voltgoCfg := c.SolarController.Voltgo
+		// Resolving first collapses the singular and list forms into one
+		// answer, so "is a battery configured at all" is asked once rather
+		// than once per form.
+		batteries, err := voltgoCfg.ResolveBatteries()
+		if err != nil {
+			return fmt.Errorf("invalid voltgo configuration: %w", err)
+		}
+		if len(batteries) == 0 {
 			return fmt.Errorf("voltgo address is required when voltgo is enabled")
 		}
-		if c.SolarController.Voltgo.PublishPeriod <= 0 {
+		if voltgoCfg.PublishPeriod <= 0 {
 			return fmt.Errorf("voltgo publish period must be positive")
 		}
-		if err := c.SolarController.Voltgo.Validate(); err != nil {
+		if err := voltgoCfg.Validate(); err != nil {
 			return fmt.Errorf("invalid voltgo configuration: %w", err)
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -276,8 +276,20 @@ solarController:
 				if !c.SolarController.Voltgo.Enabled {
 					t.Error("Voltgo should be enabled")
 				}
-				if c.SolarController.Voltgo.Address != "AA:BB:CC:DD:EE:FF" {
-					t.Errorf("Voltgo Address = %s, want AA:BB:CC:DD:EE:FF", c.SolarController.Voltgo.Address)
+				// The singular form resolves to a one-battery list whose id
+				// is derived from the address.
+				batteries, err := c.SolarController.Voltgo.ResolveBatteries()
+				if err != nil {
+					t.Fatalf("ResolveBatteries() error = %v", err)
+				}
+				if len(batteries) != 1 {
+					t.Fatalf("resolved %d batteries, want 1", len(batteries))
+				}
+				if batteries[0].Address != "AA:BB:CC:DD:EE:FF" {
+					t.Errorf("Voltgo Address = %s, want AA:BB:CC:DD:EE:FF", batteries[0].Address)
+				}
+				if batteries[0].ID != "aa-bb-cc-dd-ee-ff" {
+					t.Errorf("Voltgo battery id = %s, want aa-bb-cc-dd-ee-ff", batteries[0].ID)
 				}
 				if c.SolarController.Voltgo.PublishPeriod != 120 {
 					t.Errorf("Voltgo PublishPeriod = %d, want 120", c.SolarController.Voltgo.PublishPeriod)
@@ -342,6 +354,109 @@ solarController:
 `,
 			wantErr: true,
 			errMsg:  "voltgo publish period must be positive",
+		},
+		{
+			// The deployment this exists for: four packs, each with a
+			// human-meaningful id used in its routes, labels, and topics.
+			name: "voltgo configuration valid with a battery list",
+			yaml: `
+solarController:
+  httpPort: 8080
+  epever:
+    enabled: false
+  voltgo:
+    enabled: true
+    publishPeriod: 120
+    connectTimeout: 45s
+    batteries:
+      - id: bank-a
+        address: A4:C1:37:43:A4:33
+      - id: bank-b
+        address: A4:C1:37:43:A4:42
+      - id: bank-c
+        address: A4:C1:37:23:A4:3F
+      - address: A4:C1:37:23:A4:40
+`,
+			wantErr: false,
+			check: func(t *testing.T, c Config) {
+				batteries, err := c.SolarController.Voltgo.ResolveBatteries()
+				if err != nil {
+					t.Fatalf("ResolveBatteries() error = %v", err)
+				}
+				if len(batteries) != 4 {
+					t.Fatalf("resolved %d batteries, want 4", len(batteries))
+				}
+				if batteries[0].ID != "bank-a" || batteries[0].Address != "A4:C1:37:43:A4:33" {
+					t.Errorf("battery 0 = %+v, want {bank-a A4:C1:37:43:A4:33}", batteries[0])
+				}
+				// The fourth is configured without an id, so it gets one
+				// derived from its address.
+				if batteries[3].ID != "a4-c1-37-23-a4-40" {
+					t.Errorf("battery 3 id = %q, want a4-c1-37-23-a4-40", batteries[3].ID)
+				}
+			},
+		},
+		{
+			name: "voltgo enabled with neither address nor batteries",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    publishPeriod: 60
+`,
+			wantErr: true,
+			errMsg:  "voltgo address is required",
+		},
+		{
+			name: "voltgo rejects duplicate battery ids",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    publishPeriod: 60
+    batteries:
+      - id: bank-a
+        address: A4:C1:37:43:A4:33
+      - id: bank-a
+        address: A4:C1:37:43:A4:42
+`,
+			wantErr: true,
+			errMsg:  `voltgo battery id "bank-a" is configured more than once`,
+		},
+		{
+			name: "voltgo rejects duplicate battery addresses",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    publishPeriod: 60
+    batteries:
+      - id: bank-a
+        address: A4:C1:37:43:A4:33
+      - id: bank-b
+        address: A4:C1:37:43:A4:33
+`,
+			wantErr: true,
+			errMsg:  "is configured more than once",
+		},
+		{
+			name: "voltgo rejects the singular address alongside a battery list",
+			yaml: `
+solarController:
+  httpPort: 8080
+  voltgo:
+    enabled: true
+    publishPeriod: 60
+    address: AA:BB:CC:DD:EE:FF
+    batteries:
+      - id: bank-a
+        address: A4:C1:37:43:A4:33
+`,
+			wantErr: true,
+			errMsg:  "mutually exclusive",
 		},
 		{
 			name: "voltgo enabled but unparseable connect timeout",

--- a/internal/controllers/voltgo/api_contract_test.go
+++ b/internal/controllers/voltgo/api_contract_test.go
@@ -18,7 +18,7 @@ func TestStatusPayloadMatchesAPIContract(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		testutil.APIContractFields(t, "GET /api/voltgo/metrics"),
+		testutil.APIContractFields(t, "GET /api/voltgo/{id}/metrics"),
 		testutil.JSONFieldNames(t, payload),
 		"BatteryStatus no longer marshals to the fields docs/api-contract.json "+
 			"records; update the contract and site/src/api/types.ts together")
@@ -31,7 +31,7 @@ func TestCellPayloadMatchesAPIContract(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		testutil.APIContractFields(t, "GET /api/voltgo/metrics#cells[]"),
+		testutil.APIContractFields(t, "GET /api/voltgo/{id}/metrics#cells[]"),
 		testutil.JSONFieldNames(t, payload),
 		"Cell no longer marshals to the fields docs/api-contract.json records; "+
 			"update the contract and site/src/api/types.ts together")
@@ -42,8 +42,32 @@ func TestInfoPayloadMatchesAPIContract(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		testutil.APIContractFields(t, "GET /api/voltgo/info"),
+		testutil.APIContractFields(t, "GET /api/voltgo/{id}/info"),
 		testutil.JSONFieldNames(t, payload),
 		"BatteryInfo no longer marshals to the fields docs/api-contract.json "+
+			"records; update the contract and site/src/api/types.ts together")
+}
+
+// The index is what the frontend uses to discover which batteries exist, so
+// its shape is as much a contract as the per-battery payloads.
+func TestIndexPayloadMatchesAPIContract(t *testing.T) {
+	payload, err := json.Marshal(BatteryIndex{})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		testutil.APIContractFields(t, "GET /api/voltgo"),
+		testutil.JSONFieldNames(t, payload),
+		"BatteryIndex no longer marshals to the fields docs/api-contract.json "+
+			"records; update the contract and site/src/api/types.ts together")
+}
+
+func TestBatteryRefPayloadMatchesAPIContract(t *testing.T) {
+	payload, err := json.Marshal(BatteryRef{})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		testutil.APIContractFields(t, "GET /api/voltgo#batteries[]"),
+		testutil.JSONFieldNames(t, payload),
+		"BatteryRef no longer marshals to the fields docs/api-contract.json "+
 			"records; update the contract and site/src/api/types.ts together")
 }

--- a/internal/controllers/voltgo/battery.go
+++ b/internal/controllers/voltgo/battery.go
@@ -1,0 +1,135 @@
+package voltgo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/lumberbarons/solar-controller/internal/publish"
+	log "github.com/sirupsen/logrus"
+)
+
+// batteryRunner owns everything specific to one battery: its BLE collector,
+// its cached status and info for the HTTP handlers, and the id that
+// distinguishes its routes, Prometheus series, and publisher topics from
+// every other battery's.
+//
+// The Controller drives one runner per configured battery, so a battery that
+// cannot be reached fails inside its own collect call and leaves the rest of
+// the cycle to carry on.
+type batteryRunner struct {
+	id        string
+	address   string
+	collector *Collector
+	publisher publish.MessagePublisher
+	metrics   MetricsCollector
+	deviceID  string
+
+	mu         sync.RWMutex
+	lastStatus *BatteryStatus
+	lastInfo   *BatteryInfo
+}
+
+func newBatteryRunner(
+	id string,
+	address string,
+	collector *Collector,
+	publisher publish.MessagePublisher,
+	metrics MetricsCollector,
+	deviceID string,
+) *batteryRunner {
+	return &batteryRunner{
+		id:        id,
+		address:   address,
+		collector: collector,
+		publisher: publisher,
+		metrics:   metrics,
+		deviceID:  deviceID,
+	}
+}
+
+// collectAndPublish reads this battery and publishes its metrics. It never
+// returns an error: a battery that cannot be read reports a failure metric and
+// leaves the others in the cycle unaffected.
+func (b *batteryRunner) collectAndPublish(ctx context.Context) {
+	log.Debugf("collecting and publishing metrics for voltgo battery %s", b.id)
+
+	status, err := b.collector.GetStatus(ctx)
+	if err != nil {
+		log.Errorf("failed to collect metrics from voltgo battery %s: %s", b.id, err)
+		b.metrics.IncrementFailures(b.id)
+		b.publishMetric(CreateCollectionFailureMetric())
+		return
+	}
+
+	b.mu.Lock()
+	b.lastStatus = status
+	b.mu.Unlock()
+
+	b.metrics.SetMetrics(b.id, status)
+
+	// Fetch static battery info once, now that a connection is up
+	b.fetchInfoOnce(ctx)
+
+	for _, metric := range ConvertStatusToMetrics(status) {
+		b.publishMetric(metric)
+	}
+
+	log.Debugf("collection done for voltgo battery %s", b.id)
+}
+
+// publishMetric publishes one metric under this battery's topic.
+//
+// The battery id is its own segment rather than part of the metric name so a
+// subscriber can still wildcard a metric across every battery
+// (`solar/+/voltgo/+/battery-soc`) as well as every metric of one battery.
+func (b *batteryRunner) publishMetric(metric Metric) {
+	payload, err := metric.ToJSON()
+	if err != nil {
+		log.Errorf("failed to marshal metric %s for voltgo battery %s: %s", metric.Name, b.id, err)
+		return
+	}
+
+	topicSuffix := fmt.Sprintf("%s/%s/%s/%s", b.deviceID, namespace, b.id, metric.Name)
+	b.publisher.Publish(topicSuffix, payload)
+	log.Debugf("published metric %s to %s", metric.Name, topicSuffix)
+}
+
+// fetchInfoOnce caches static battery info on the first successful collection
+// cycle. Failures are logged but never fail the cycle - the next cycle retries.
+func (b *batteryRunner) fetchInfoOnce(ctx context.Context) {
+	b.mu.RLock()
+	cached := b.lastInfo != nil
+	b.mu.RUnlock()
+	if cached {
+		return
+	}
+
+	info, err := b.collector.GetInfo(ctx)
+	if err != nil {
+		log.Warnf("failed to read voltgo battery %s info: %s", b.id, err)
+		return
+	}
+
+	b.mu.Lock()
+	b.lastInfo = info
+	b.mu.Unlock()
+	log.Debugf("cached voltgo battery %s info: %s %.1fV %.0fAh",
+		b.id, info.Chemistry, info.NominalVoltage, info.CapacityAh)
+}
+
+func (b *batteryRunner) status() *BatteryStatus {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.lastStatus
+}
+
+func (b *batteryRunner) info() *BatteryInfo {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.lastInfo
+}
+
+func (b *batteryRunner) close() error {
+	return b.collector.Close()
+}

--- a/internal/controllers/voltgo/collector.go
+++ b/internal/controllers/voltgo/collector.go
@@ -122,13 +122,18 @@ func (c *Collector) GetInfo(ctx context.Context) (*BatteryInfo, error) {
 	}, nil
 }
 
-// Close drops any active battery connection and releases the BLE adapter.
+// Close drops any active battery connection.
+//
+// The BLE adapter behind the connector is deliberately left alone: it is
+// shared by every battery's collector, so releasing it here would tear it out
+// from under the other batteries. The Controller closes it once, after every
+// collector has disconnected.
 func (c *Collector) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.dropConnectionLocked()
-	return c.connector.Close()
+	return nil
 }
 
 // connectLocked returns the current battery connection, establishing or

--- a/internal/controllers/voltgo/collector_test.go
+++ b/internal/controllers/voltgo/collector_test.go
@@ -299,7 +299,7 @@ func TestCollector_GetInfo(t *testing.T) {
 func TestCollector_Close(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("disconnects battery and closes connector", func(t *testing.T) {
+	t.Run("disconnects battery but leaves the shared adapter alone", func(t *testing.T) {
 		mockBattery := &MockBatteryClient{
 			GetStatusFunc: func(_ context.Context) (*battery.Status, error) {
 				return testBatteryStatus(), nil
@@ -322,58 +322,23 @@ func TestCollector_Close(t *testing.T) {
 		if mockBattery.DisconnectCalls != 1 {
 			t.Errorf("Disconnect calls = %d, want 1", mockBattery.DisconnectCalls)
 		}
-		if mockConnector.CloseCalls != 1 {
-			t.Errorf("connector Close calls = %d, want 1", mockConnector.CloseCalls)
+		// The connector is one BLE adapter shared by every battery, so a
+		// single collector closing must not take it down for the others.
+		// The Controller releases it once, after all collectors are closed.
+		if mockConnector.CloseCalls != 0 {
+			t.Errorf("connector Close calls = %d, want 0", mockConnector.CloseCalls)
 		}
 	})
 
-	t.Run("closes connector when never connected", func(t *testing.T) {
+	t.Run("close is a no-op when never connected", func(t *testing.T) {
 		mockConnector := &MockBatteryConnector{}
 
 		collector := NewCollector(mockConnector, "AA:BB:CC:DD:EE:FF", 10*time.Second)
 		if err := collector.Close(); err != nil {
 			t.Fatalf("Close() error = %v", err)
 		}
-		if mockConnector.CloseCalls != 1 {
-			t.Errorf("connector Close calls = %d, want 1", mockConnector.CloseCalls)
+		if mockConnector.CloseCalls != 0 {
+			t.Errorf("connector Close calls = %d, want 0", mockConnector.CloseCalls)
 		}
 	})
-}
-
-func TestConfiguration_GetConnectTimeout(t *testing.T) {
-	tests := []struct {
-		name    string
-		timeout string
-		want    time.Duration
-	}{
-		{"default when empty", "", 30 * time.Second},
-		{"parses valid duration", "45s", 45 * time.Second},
-		{"default on invalid duration", "bogus", 30 * time.Second},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Configuration{ConnectTimeout: tt.timeout}
-			if got := c.GetConnectTimeout(); got != tt.want {
-				t.Errorf("GetConnectTimeout() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestConfiguration_Validate(t *testing.T) {
-	valid := &Configuration{ConnectTimeout: "10s"}
-	if err := valid.Validate(); err != nil {
-		t.Errorf("Validate() error = %v, want nil", err)
-	}
-
-	empty := &Configuration{}
-	if err := empty.Validate(); err != nil {
-		t.Errorf("Validate() error = %v, want nil for empty timeout", err)
-	}
-
-	invalid := &Configuration{ConnectTimeout: "bogus"}
-	if err := invalid.Validate(); err == nil {
-		t.Error("Validate() should return an error for an invalid duration")
-	}
 }

--- a/internal/controllers/voltgo/config.go
+++ b/internal/controllers/voltgo/config.go
@@ -1,0 +1,135 @@
+package voltgo
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const defaultConnectTimeout = 30 * time.Second
+
+// batteryIDPattern constrains a battery id to characters that are safe
+// unescaped in all three places an id appears: a URL path segment, a
+// Prometheus label value, and an MQTT/Solace topic segment. Slashes, spaces,
+// and `+`/`#` would each break at least one of those.
+var batteryIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// BatteryConfiguration describes one physical battery on the BLE bus.
+type BatteryConfiguration struct {
+	// ID identifies this battery in routes, Prometheus labels, and publisher
+	// topics. Optional: defaults to the address, lowercased with colons
+	// replaced by dashes.
+	ID string `yaml:"id"`
+
+	// Address is the BLE address of the battery, e.g. AA:BB:CC:DD:EE:FF.
+	Address string `yaml:"address"`
+}
+
+type Configuration struct {
+	Enabled bool `yaml:"enabled"`
+
+	// Address configures a single battery.
+	//
+	// Deprecated: use Batteries. Retained so an existing single-battery
+	// config keeps working; it is an error to set both.
+	Address string `yaml:"address"`
+
+	// Batteries lists every battery to collect from. Collection is
+	// serialised across them, so PublishPeriod must leave room for one
+	// connect-and-read per battery.
+	Batteries []BatteryConfiguration `yaml:"batteries"`
+
+	PublishPeriod int `yaml:"publishPeriod"`
+
+	// ConnectTimeout is the maximum time to wait for a BLE connection,
+	// as a duration string (default: 30s). It applies per battery.
+	ConnectTimeout string `yaml:"connectTimeout"`
+}
+
+// Validate checks the configuration for errors. Only called when enabled.
+func (c *Configuration) Validate() error {
+	if c.ConnectTimeout != "" {
+		if _, err := time.ParseDuration(c.ConnectTimeout); err != nil {
+			return err
+		}
+	}
+	if _, err := c.ResolveBatteries(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ResolveBatteries normalises the singular and list forms into one list with
+// every id filled in, and rejects a configuration that cannot be collected
+// from unambiguously.
+//
+// Duplicate ids and duplicate addresses are both errors rather than warnings:
+// a duplicate id would silently collapse two batteries onto one route,
+// one Prometheus series, and one topic, and a duplicate address would have two
+// runners fighting over the same BLE connection.
+func (c *Configuration) ResolveBatteries() ([]BatteryConfiguration, error) {
+	if c.Address != "" && len(c.Batteries) > 0 {
+		return nil, fmt.Errorf("voltgo address and batteries are mutually exclusive; " +
+			"move the single address into the batteries list")
+	}
+
+	configured := c.Batteries
+	if c.Address != "" {
+		configured = []BatteryConfiguration{{Address: c.Address}}
+	}
+
+	resolved := make([]BatteryConfiguration, 0, len(configured))
+	seenIDs := make(map[string]struct{}, len(configured))
+	seenAddrs := make(map[string]struct{}, len(configured))
+
+	for i, battery := range configured {
+		if battery.Address == "" {
+			return nil, fmt.Errorf("voltgo battery %d: address is required", i)
+		}
+
+		id := battery.ID
+		if id == "" {
+			id = DefaultBatteryID(battery.Address)
+		}
+		if !batteryIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("voltgo battery %q: id must match %s", id, batteryIDPattern)
+		}
+
+		if _, dup := seenIDs[id]; dup {
+			return nil, fmt.Errorf("voltgo battery id %q is configured more than once", id)
+		}
+		seenIDs[id] = struct{}{}
+
+		// Addresses are compared case-insensitively: BlueZ and the
+		// datasheet disagree on the case of the hex digits, so the same
+		// battery is easily written both ways.
+		addr := strings.ToUpper(battery.Address)
+		if _, dup := seenAddrs[addr]; dup {
+			return nil, fmt.Errorf("voltgo battery address %q is configured more than once", battery.Address)
+		}
+		seenAddrs[addr] = struct{}{}
+
+		resolved = append(resolved, BatteryConfiguration{ID: id, Address: battery.Address})
+	}
+
+	return resolved, nil
+}
+
+// DefaultBatteryID derives an id from a BLE address, for a battery configured
+// without one.
+func DefaultBatteryID(address string) string {
+	return strings.ToLower(strings.ReplaceAll(address, ":", "-"))
+}
+
+// GetConnectTimeout returns the configured connect timeout or the default (30s).
+func (c *Configuration) GetConnectTimeout() time.Duration {
+	if c.ConnectTimeout == "" {
+		return defaultConnectTimeout
+	}
+	timeout, err := time.ParseDuration(c.ConnectTimeout)
+	if err != nil {
+		return defaultConnectTimeout
+	}
+	return timeout
+}

--- a/internal/controllers/voltgo/config_test.go
+++ b/internal/controllers/voltgo/config_test.go
@@ -1,0 +1,235 @@
+package voltgo
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolveBatteries(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Configuration
+		want    []BatteryConfiguration
+		wantErr string
+	}{
+		{
+			name:   "no batteries resolves to an empty list",
+			config: Configuration{Enabled: true},
+			want:   []BatteryConfiguration{},
+		},
+		{
+			// The deprecated singular form is what every existing
+			// deployment has in its config file today.
+			name:   "singular address is treated as one battery",
+			config: Configuration{Enabled: true, Address: "AA:BB:CC:DD:EE:FF"},
+			want:   []BatteryConfiguration{{ID: "aa-bb-cc-dd-ee-ff", Address: "AA:BB:CC:DD:EE:FF"}},
+		},
+		{
+			name: "battery without an id gets one derived from its address",
+			config: Configuration{
+				Enabled:   true,
+				Batteries: []BatteryConfiguration{{Address: "A4:C1:37:43:A4:33"}},
+			},
+			want: []BatteryConfiguration{{ID: "a4-c1-37-43-a4-33", Address: "A4:C1:37:43:A4:33"}},
+		},
+		{
+			name: "configured ids are preserved in order",
+			config: Configuration{
+				Enabled: true,
+				Batteries: []BatteryConfiguration{
+					{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+					{ID: "bank-b", Address: "A4:C1:37:43:A4:42"},
+					{ID: "bank-c", Address: "A4:C1:37:23:A4:3F"},
+					{ID: "bank-d", Address: "A4:C1:37:23:A4:40"},
+				},
+			},
+			want: []BatteryConfiguration{
+				{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+				{ID: "bank-b", Address: "A4:C1:37:43:A4:42"},
+				{ID: "bank-c", Address: "A4:C1:37:23:A4:3F"},
+				{ID: "bank-d", Address: "A4:C1:37:23:A4:40"},
+			},
+		},
+		{
+			name: "address and batteries together is an error",
+			config: Configuration{
+				Enabled:   true,
+				Address:   "AA:BB:CC:DD:EE:FF",
+				Batteries: []BatteryConfiguration{{Address: "A4:C1:37:43:A4:33"}},
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "battery without an address is an error",
+			config: Configuration{
+				Enabled:   true,
+				Batteries: []BatteryConfiguration{{ID: "bank-a"}},
+			},
+			wantErr: "address is required",
+		},
+		{
+			name: "duplicate id is an error",
+			config: Configuration{
+				Enabled: true,
+				Batteries: []BatteryConfiguration{
+					{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+					{ID: "bank-a", Address: "A4:C1:37:43:A4:42"},
+				},
+			},
+			wantErr: `id "bank-a" is configured more than once`,
+		},
+		{
+			// Two batteries sharing one address would be two runners
+			// fighting over the same BLE connection.
+			name: "duplicate address is an error",
+			config: Configuration{
+				Enabled: true,
+				Batteries: []BatteryConfiguration{
+					{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+					{ID: "bank-b", Address: "A4:C1:37:43:A4:33"},
+				},
+			},
+			wantErr: "is configured more than once",
+		},
+		{
+			// BlueZ lowercases addresses; the datasheet uppercases them.
+			// Comparing case-sensitively would let the same battery in twice.
+			name: "duplicate address differing only in case is an error",
+			config: Configuration{
+				Enabled: true,
+				Batteries: []BatteryConfiguration{
+					{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+					{ID: "bank-b", Address: "a4:c1:37:43:a4:33"},
+				},
+			},
+			wantErr: "is configured more than once",
+		},
+		{
+			// An id with a slash would split into two path segments and two
+			// topic levels; the derived-from-address default cannot produce
+			// one, but a hand-written id can.
+			name: "id with a path separator is an error",
+			config: Configuration{
+				Enabled:   true,
+				Batteries: []BatteryConfiguration{{ID: "bank/a", Address: "A4:C1:37:43:A4:33"}},
+			},
+			wantErr: "id must match",
+		},
+		{
+			name: "id with an MQTT wildcard character is an error",
+			config: Configuration{
+				Enabled:   true,
+				Batteries: []BatteryConfiguration{{ID: "bank+a", Address: "A4:C1:37:43:A4:33"}},
+			},
+			wantErr: "id must match",
+		},
+		{
+			name: "id with uppercase is an error",
+			config: Configuration{
+				Enabled:   true,
+				Batteries: []BatteryConfiguration{{ID: "BankA", Address: "A4:C1:37:43:A4:33"}},
+			},
+			wantErr: "id must match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.config.ResolveBatteries()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveBatteries() error = nil, want an error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ResolveBatteries() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ResolveBatteries() error = %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ResolveBatteries() = %+v, want %+v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("battery %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConfigurationValidate(t *testing.T) {
+	t.Run("rejects an unparseable connect timeout", func(t *testing.T) {
+		config := Configuration{Enabled: true, Address: "AA:BB:CC:DD:EE:FF", ConnectTimeout: "nonsense"}
+		if err := config.Validate(); err == nil {
+			t.Error("Validate() error = nil, want a parse error")
+		}
+	})
+
+	t.Run("surfaces battery list errors", func(t *testing.T) {
+		config := Configuration{
+			Enabled: true,
+			Batteries: []BatteryConfiguration{
+				{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+				{ID: "bank-a", Address: "A4:C1:37:43:A4:42"},
+			},
+		}
+		if err := config.Validate(); err == nil {
+			t.Error("Validate() error = nil, want a duplicate id error")
+		}
+	})
+
+	t.Run("accepts a valid multi-battery configuration", func(t *testing.T) {
+		config := Configuration{
+			Enabled:        true,
+			ConnectTimeout: "45s",
+			Batteries: []BatteryConfiguration{
+				{ID: "bank-a", Address: "A4:C1:37:43:A4:33"},
+				{ID: "bank-b", Address: "A4:C1:37:43:A4:42"},
+			},
+		}
+		if err := config.Validate(); err != nil {
+			t.Errorf("Validate() error = %v", err)
+		}
+		if got := config.GetConnectTimeout(); got != 45*time.Second {
+			t.Errorf("GetConnectTimeout() = %s, want 45s", got)
+		}
+	})
+}
+
+func TestGetConnectTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{"empty falls back to the default", "", defaultConnectTimeout},
+		{"unparseable falls back to the default", "not-a-duration", defaultConnectTimeout},
+		{"parseable is used as configured", "15s", 15 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Configuration{ConnectTimeout: tt.timeout}
+			if got := config.GetConnectTimeout(); got != tt.want {
+				t.Errorf("GetConnectTimeout() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultBatteryID(t *testing.T) {
+	if got := DefaultBatteryID("A4:C1:37:43:A4:33"); got != "a4-c1-37-43-a4-33" {
+		t.Errorf("DefaultBatteryID() = %q, want %q", got, "a4-c1-37-43-a4-33")
+	}
+	// The derived id has to satisfy the same pattern a configured id does,
+	// or a battery configured without an id could never start.
+	if !batteryIDPattern.MatchString(DefaultBatteryID("A4:C1:37:43:A4:33")) {
+		t.Error("a derived id must satisfy batteryIDPattern")
+	}
+}

--- a/internal/controllers/voltgo/interfaces.go
+++ b/internal/controllers/voltgo/interfaces.go
@@ -26,12 +26,15 @@ type BatteryClient interface {
 
 // MetricsCollector defines the interface for collecting and exposing metrics.
 // This abstraction allows for testing without the Prometheus global registry.
+//
+// Every method takes the battery id: one collector serves every configured
+// battery, and the id is what keeps their series apart.
 type MetricsCollector interface {
-	// IncrementFailures increments the collection failure counter.
-	IncrementFailures()
+	// IncrementFailures increments the collection failure counter for one battery.
+	IncrementFailures(batteryID string)
 
-	// SetMetrics updates all metrics based on the provided status.
-	SetMetrics(status *BatteryStatus)
+	// SetMetrics updates all metrics for one battery based on the provided status.
+	SetMetrics(batteryID string, status *BatteryStatus)
 }
 
 // BatteryConnector defines the interface for establishing BLE connections

--- a/internal/controllers/voltgo/mocks_test.go
+++ b/internal/controllers/voltgo/mocks_test.go
@@ -72,40 +72,62 @@ func (m *MockBatteryClient) Disconnect() error {
 	return nil
 }
 
+// SetMetricsCall records one SetMetrics invocation, including which battery
+// it was for: with several batteries sharing one collector, the id is the
+// only thing distinguishing their updates.
+type SetMetricsCall struct {
+	BatteryID string
+	Status    *BatteryStatus
+}
+
 // MockMetricsCollector is a mock implementation of the MetricsCollector interface for testing.
 type MockMetricsCollector struct {
 	mu sync.RWMutex
 
 	// Function fields that can be set to customize behavior in tests
-	IncrementFailuresFunc func()
-	SetMetricsFunc        func(status *BatteryStatus)
+	IncrementFailuresFunc func(batteryID string)
+	SetMetricsFunc        func(batteryID string, status *BatteryStatus)
 
 	// Call tracking
 	FailuresCount   int
-	SetMetricsCalls []*BatteryStatus
+	FailureIDs      []string
+	SetMetricsCalls []SetMetricsCall
 }
 
 // Verify MockMetricsCollector implements MetricsCollector
 var _ MetricsCollector = (*MockMetricsCollector)(nil)
 
-func (m *MockMetricsCollector) IncrementFailures() {
+func (m *MockMetricsCollector) IncrementFailures(batteryID string) {
 	m.mu.Lock()
 	m.FailuresCount++
+	m.FailureIDs = append(m.FailureIDs, batteryID)
 	m.mu.Unlock()
 
 	if m.IncrementFailuresFunc != nil {
-		m.IncrementFailuresFunc()
+		m.IncrementFailuresFunc(batteryID)
 	}
 }
 
-func (m *MockMetricsCollector) SetMetrics(status *BatteryStatus) {
+func (m *MockMetricsCollector) SetMetrics(batteryID string, status *BatteryStatus) {
 	m.mu.Lock()
-	m.SetMetricsCalls = append(m.SetMetricsCalls, status)
+	m.SetMetricsCalls = append(m.SetMetricsCalls, SetMetricsCall{BatteryID: batteryID, Status: status})
 	m.mu.Unlock()
 
 	if m.SetMetricsFunc != nil {
-		m.SetMetricsFunc(status)
+		m.SetMetricsFunc(batteryID, status)
 	}
+}
+
+// metricsBatteryIDs returns the battery ids SetMetrics was called for, in order.
+func (m *MockMetricsCollector) metricsBatteryIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ids := make([]string, 0, len(m.SetMetricsCalls))
+	for _, call := range m.SetMetricsCalls {
+		ids = append(ids, call.BatteryID)
+	}
+	return ids
 }
 
 // MockBatteryConnector is a mock implementation of the BatteryConnector interface for testing.

--- a/internal/controllers/voltgo/prometheus.go
+++ b/internal/controllers/voltgo/prometheus.go
@@ -7,27 +7,36 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// batteryLabel names the series dimension that separates one battery from
+// another. Every voltgo series carries it, including the single-battery case,
+// so a query written against one battery keeps working when a second is added.
+const batteryLabel = "battery"
+
+// PrometheusCollector exposes every configured battery through one set of
+// labelled metrics. One instance is shared by all batteries: promauto
+// registers into the default registry, which panics on a duplicate
+// registration, so a per-battery collector is not an option.
 type PrometheusCollector struct {
-	failures prometheus.Counter
+	failures *prometheus.CounterVec
 
-	batteryVoltage prometheus.Gauge
-	batteryCurrent prometheus.Gauge
-	batteryPower   prometheus.Gauge
-	batterySoc     prometheus.Gauge
-	batterySoh     prometheus.Gauge
-	batteryTemp    prometheus.Gauge
+	batteryVoltage *prometheus.GaugeVec
+	batteryCurrent *prometheus.GaugeVec
+	batteryPower   *prometheus.GaugeVec
+	batterySoc     *prometheus.GaugeVec
+	batterySoh     *prometheus.GaugeVec
+	batteryTemp    *prometheus.GaugeVec
 
-	cellVoltageDelta prometheus.Gauge
+	cellVoltageDelta *prometheus.GaugeVec
 	cellVoltage      *prometheus.GaugeVec
 }
 
 func NewPrometheusCollector() *PrometheusCollector {
 	endpoint := &PrometheusCollector{
-		failures: promauto.NewCounter(prometheus.CounterOpts{
+		failures: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "read_failures",
 			Help:      "Number of errors while reading from the voltgo battery.",
-		}),
+		}, []string{batteryLabel}),
 	}
 
 	// Initialize all metrics immediately to avoid race conditions
@@ -36,52 +45,21 @@ func NewPrometheusCollector() *PrometheusCollector {
 	return endpoint
 }
 
-func (v *PrometheusCollector) IncrementFailures() {
-	v.failures.Inc()
+func (v *PrometheusCollector) IncrementFailures(batteryID string) {
+	v.failures.WithLabelValues(batteryID).Inc()
 }
 
 func (v *PrometheusCollector) initializeMetrics() {
-	v.batteryVoltage = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "battery_voltage",
-		Help:      "Battery pack voltage (V).",
-	})
-
-	v.batteryCurrent = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "battery_current",
-		Help:      "Battery pack current (A), positive when charging, negative when discharging.",
-	})
-
-	v.batteryPower = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "battery_power",
-		Help:      "Battery pack power (W), derived from voltage and current.",
-	})
-
-	v.batterySoc = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "battery_soc",
-		Help:      "Battery state of charge (%).",
-	})
-
-	v.batterySoh = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "battery_soh",
-		Help:      "Battery state of health (%).",
-	})
-
-	v.batteryTemp = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "battery_temp",
-		Help:      "Battery temperature (C).",
-	})
-
-	v.cellVoltageDelta = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "cell_voltage_delta",
-		Help:      "Spread between the highest and lowest cell voltage (V).",
-	})
+	v.batteryVoltage = v.newBatteryGauge("battery_voltage", "Battery pack voltage (V).")
+	v.batteryCurrent = v.newBatteryGauge("battery_current",
+		"Battery pack current (A), positive when charging, negative when discharging.")
+	v.batteryPower = v.newBatteryGauge("battery_power",
+		"Battery pack power (W), derived from voltage and current.")
+	v.batterySoc = v.newBatteryGauge("battery_soc", "Battery state of charge (%).")
+	v.batterySoh = v.newBatteryGauge("battery_soh", "Battery state of health (%).")
+	v.batteryTemp = v.newBatteryGauge("battery_temp", "Battery temperature (C).")
+	v.cellVoltageDelta = v.newBatteryGauge("cell_voltage_delta",
+		"Spread between the highest and lowest cell voltage (V).")
 
 	v.cellVoltage = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -89,20 +67,31 @@ func (v *PrometheusCollector) initializeMetrics() {
 			Name:      "cell_voltage",
 			Help:      "Individual cell voltage (V).",
 		},
-		[]string{"cell"},
+		[]string{batteryLabel, "cell"},
 	)
 }
 
-func (v *PrometheusCollector) SetMetrics(status *BatteryStatus) {
-	v.batteryVoltage.Set(status.Voltage)
-	v.batteryCurrent.Set(status.Current)
-	v.batteryPower.Set(status.Voltage * status.Current)
-	v.batterySoc.Set(float64(status.SOC))
-	v.batterySoh.Set(float64(status.SOH))
-	v.batteryTemp.Set(status.Temperature)
+func (v *PrometheusCollector) newBatteryGauge(name, help string) *prometheus.GaugeVec {
+	return promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      name,
+			Help:      help,
+		},
+		[]string{batteryLabel},
+	)
+}
 
-	v.cellVoltageDelta.Set(cellVoltageDelta(status.Cells))
+func (v *PrometheusCollector) SetMetrics(batteryID string, status *BatteryStatus) {
+	v.batteryVoltage.WithLabelValues(batteryID).Set(status.Voltage)
+	v.batteryCurrent.WithLabelValues(batteryID).Set(status.Current)
+	v.batteryPower.WithLabelValues(batteryID).Set(status.Voltage * status.Current)
+	v.batterySoc.WithLabelValues(batteryID).Set(float64(status.SOC))
+	v.batterySoh.WithLabelValues(batteryID).Set(float64(status.SOH))
+	v.batteryTemp.WithLabelValues(batteryID).Set(status.Temperature)
+
+	v.cellVoltageDelta.WithLabelValues(batteryID).Set(cellVoltageDelta(status.Cells))
 	for _, cell := range status.Cells {
-		v.cellVoltage.WithLabelValues(strconv.Itoa(cell.Index)).Set(cell.Voltage)
+		v.cellVoltage.WithLabelValues(batteryID, strconv.Itoa(cell.Index)).Set(cell.Voltage)
 	}
 }

--- a/internal/controllers/voltgo/prometheus_test.go
+++ b/internal/controllers/voltgo/prometheus_test.go
@@ -14,11 +14,11 @@ var _ MetricsCollector = (*PrometheusCollector)(nil)
 func TestPrometheusCollector(t *testing.T) {
 	collector := NewPrometheusCollector()
 
-	t.Run("SetMetrics updates all gauges", func(t *testing.T) {
-		status := &BatteryStatus{
-			Voltage:     13.28,
+	statusFor := func(voltage float64, soc int) *BatteryStatus {
+		return &BatteryStatus{
+			Voltage:     voltage,
 			Current:     -2.5,
-			SOC:         87,
+			SOC:         soc,
 			SOH:         100,
 			Temperature: 21.5,
 			CellCount:   4,
@@ -29,39 +29,83 @@ func TestPrometheusCollector(t *testing.T) {
 				{Index: 3, Voltage: 3.319},
 			},
 		}
+	}
 
-		collector.SetMetrics(status)
+	t.Run("SetMetrics updates all gauges under the battery label", func(t *testing.T) {
+		status := statusFor(13.28, 87)
+		collector.SetMetrics("bank-a", status)
 
 		checks := []struct {
 			name string
 			got  float64
 			want float64
 		}{
-			{"battery_voltage", testutil.ToFloat64(collector.batteryVoltage), 13.28},
-			{"battery_current", testutil.ToFloat64(collector.batteryCurrent), -2.5},
-			{"battery_power", testutil.ToFloat64(collector.batteryPower), status.Voltage * status.Current},
-			{"battery_soc", testutil.ToFloat64(collector.batterySoc), 87},
-			{"battery_soh", testutil.ToFloat64(collector.batterySoh), 100},
-			{"battery_temp", testutil.ToFloat64(collector.batteryTemp), 21.5},
-			{"cell_voltage_delta", testutil.ToFloat64(collector.cellVoltageDelta), status.Cells[2].Voltage - status.Cells[1].Voltage},
+			{"battery_voltage", testutil.ToFloat64(collector.batteryVoltage.WithLabelValues("bank-a")), 13.28},
+			{"battery_current", testutil.ToFloat64(collector.batteryCurrent.WithLabelValues("bank-a")), -2.5},
+			{"battery_power", testutil.ToFloat64(collector.batteryPower.WithLabelValues("bank-a")), status.Voltage * status.Current},
+			{"battery_soc", testutil.ToFloat64(collector.batterySoc.WithLabelValues("bank-a")), 87},
+			{"battery_soh", testutil.ToFloat64(collector.batterySoh.WithLabelValues("bank-a")), 100},
+			{"battery_temp", testutil.ToFloat64(collector.batteryTemp.WithLabelValues("bank-a")), 21.5},
+			{"cell_voltage_delta", testutil.ToFloat64(collector.cellVoltageDelta.WithLabelValues("bank-a")), status.Cells[2].Voltage - status.Cells[1].Voltage},
 		}
 
 		for _, c := range checks {
 			if c.got != c.want {
-				t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+				t.Errorf("%s{battery=\"bank-a\"} = %v, want %v", c.name, c.got, c.want)
 			}
 		}
 
-		if got := testutil.ToFloat64(collector.cellVoltage.WithLabelValues("2")); got != 3.322 {
-			t.Errorf("cell_voltage{cell=\"2\"} = %v, want 3.322", got)
+		if got := testutil.ToFloat64(collector.cellVoltage.WithLabelValues("bank-a", "2")); got != 3.322 {
+			t.Errorf("cell_voltage{battery=\"bank-a\",cell=\"2\"} = %v, want 3.322", got)
 		}
 	})
 
-	t.Run("IncrementFailures increments the counter", func(t *testing.T) {
-		before := testutil.ToFloat64(collector.failures)
-		collector.IncrementFailures()
-		if got := testutil.ToFloat64(collector.failures); got != before+1 {
-			t.Errorf("read_failures = %v, want %v", got, before+1)
+	// Without the battery label, four packs would overwrite each other's
+	// values and the dashboard would show whichever collected last.
+	t.Run("batteries do not overwrite each other", func(t *testing.T) {
+		collector.SetMetrics("bank-a", statusFor(13.28, 87))
+		collector.SetMetrics("bank-b", statusFor(12.90, 64))
+
+		if got := testutil.ToFloat64(collector.batteryVoltage.WithLabelValues("bank-a")); got != 13.28 {
+			t.Errorf("battery_voltage{battery=\"bank-a\"} = %v, want 13.28", got)
+		}
+		if got := testutil.ToFloat64(collector.batteryVoltage.WithLabelValues("bank-b")); got != 12.90 {
+			t.Errorf("battery_voltage{battery=\"bank-b\"} = %v, want 12.90", got)
+		}
+		if got := testutil.ToFloat64(collector.batterySoc.WithLabelValues("bank-a")); got != 87 {
+			t.Errorf("battery_soc{battery=\"bank-a\"} = %v, want 87", got)
+		}
+		if got := testutil.ToFloat64(collector.batterySoc.WithLabelValues("bank-b")); got != 64 {
+			t.Errorf("battery_soc{battery=\"bank-b\"} = %v, want 64", got)
+		}
+	})
+
+	// The cell label alone is not enough: cell 2 of one pack and cell 2 of
+	// another are different cells.
+	t.Run("cell voltages are separated by battery as well as cell", func(t *testing.T) {
+		perBattery := statusFor(13.28, 87)
+		perBattery.Cells = []Cell{{Index: 0, Voltage: 3.400}}
+		collector.SetMetrics("bank-c", perBattery)
+
+		if got := testutil.ToFloat64(collector.cellVoltage.WithLabelValues("bank-c", "0")); got != 3.400 {
+			t.Errorf("cell_voltage{battery=\"bank-c\",cell=\"0\"} = %v, want 3.400", got)
+		}
+		if got := testutil.ToFloat64(collector.cellVoltage.WithLabelValues("bank-a", "0")); got != 3.321 {
+			t.Errorf("cell_voltage{battery=\"bank-a\",cell=\"0\"} = %v, want 3.321 (bank-c must not overwrite it)", got)
+		}
+	})
+
+	t.Run("IncrementFailures increments the counter for one battery only", func(t *testing.T) {
+		beforeA := testutil.ToFloat64(collector.failures.WithLabelValues("bank-a"))
+		beforeB := testutil.ToFloat64(collector.failures.WithLabelValues("bank-b"))
+
+		collector.IncrementFailures("bank-a")
+
+		if got := testutil.ToFloat64(collector.failures.WithLabelValues("bank-a")); got != beforeA+1 {
+			t.Errorf("read_failures{battery=\"bank-a\"} = %v, want %v", got, beforeA+1)
+		}
+		if got := testutil.ToFloat64(collector.failures.WithLabelValues("bank-b")); got != beforeB {
+			t.Errorf("read_failures{battery=\"bank-b\"} = %v, want %v (unchanged)", got, beforeB)
 		}
 	})
 }

--- a/internal/controllers/voltgo/voltgo.go
+++ b/internal/controllers/voltgo/voltgo.go
@@ -16,85 +16,58 @@ import (
 const (
 	namespace = "voltgo"
 
-	defaultConnectTimeout = 30 * time.Second
-
-	// collectTimeout bounds a full collection cycle: a BLE connect
-	// (default 30s) plus the status reads.
+	// collectTimeout bounds one battery's collection: a BLE connect
+	// (default 30s) plus the status reads. Each battery in a cycle gets its
+	// own budget, because a cycle is serialised across them.
 	collectTimeout = 60 * time.Second
 )
 
-type Configuration struct {
-	Enabled       bool   `yaml:"enabled"`
-	Address       string `yaml:"address"`
-	PublishPeriod int    `yaml:"publishPeriod"`
-
-	// ConnectTimeout is the maximum time to wait for a BLE connection,
-	// as a duration string (default: 30s)
-	ConnectTimeout string `yaml:"connectTimeout"`
+// BatteryRef identifies one configured battery in the index endpoint, so the
+// frontend can discover which batteries exist rather than hardcoding them.
+type BatteryRef struct {
+	ID      string `json:"id"`
+	Address string `json:"address"`
 }
 
-// Validate checks the configuration for errors. Only called when enabled.
-func (c *Configuration) Validate() error {
-	if c.ConnectTimeout != "" {
-		if _, err := time.ParseDuration(c.ConnectTimeout); err != nil {
-			return err
-		}
-	}
-	return nil
+// BatteryIndex is the payload of GET /api/voltgo.
+type BatteryIndex struct {
+	Batteries []BatteryRef `json:"batteries"`
 }
 
-// GetConnectTimeout returns the configured connect timeout or the default (30s).
-func (c *Configuration) GetConnectTimeout() time.Duration {
-	if c.ConnectTimeout == "" {
-		return defaultConnectTimeout
-	}
-	timeout, err := time.ParseDuration(c.ConnectTimeout)
-	if err != nil {
-		return defaultConnectTimeout
-	}
-	return timeout
-}
-
+// Controller drives every configured voltgo battery. It is one controller
+// rather than one per battery because the three things that have to be unique
+// - the Gin routes, the Prometheus registration, and the BLE adapter - are all
+// process-wide: registering them once here is what lets a second battery exist
+// at all.
 type Controller struct {
-	collector           *Collector
-	publisher           publish.MessagePublisher
-	prometheusCollector MetricsCollector
-	scheduler           *gocron.Scheduler
-	deviceID            string
-	lastStatus          *BatteryStatus
-	lastInfo            *BatteryInfo
-	lastStatusMutex     sync.RWMutex
-	collectInProgress   bool
-	collectMutex        sync.Mutex
+	batteries []*batteryRunner
+	byID      map[string]*batteryRunner
+
+	// connector is the shared BLE adapter behind every battery's collector,
+	// owned here so it is released exactly once on Close.
+	connector BatteryConnector
+
+	scheduler *gocron.Scheduler
+
+	collectInProgress bool
+	collectMutex      sync.Mutex
 }
 
-// NewController creates a new voltgo controller with dependency injection for testing.
-// For production use, call NewControllerFromConfig instead.
+// NewController creates a voltgo controller from already-built battery
+// runners, for testing. For production use, call NewControllerFromConfig.
 func NewController(
-	collector *Collector,
-	publisher publish.MessagePublisher,
-	prometheusCollector MetricsCollector,
-	deviceID string,
+	batteries []*batteryRunner,
+	connector BatteryConnector,
 	publishPeriod int,
 ) (*Controller, error) {
-	if collector == nil {
+	if len(batteries) == 0 {
 		return &Controller{}, nil
 	}
 
-	// Default device ID if not provided
-	if deviceID == "" {
-		deviceID = "controller-1"
-	}
+	controller := newControllerForTest(batteries, connector)
 
 	s := gocron.NewScheduler(time.UTC)
-
-	controller := &Controller{
-		collector:           collector,
-		publisher:           publisher,
-		prometheusCollector: prometheusCollector,
-		deviceID:            deviceID,
-		scheduler:           s,
-	}
+	controller.scheduler = s
 
 	_, err := s.Every(publishPeriod).Seconds().Do(controller.collectAndPublish)
 	if err != nil {
@@ -109,22 +82,18 @@ func NewController(
 	return controller, nil
 }
 
-// newControllerForTest creates a Controller without starting the scheduler or background goroutine.
-// This allows tests to call collectAndPublish synchronously without racing.
-func newControllerForTest(
-	collector *Collector,
-	publisher publish.MessagePublisher,
-	prometheusCollector MetricsCollector,
-	deviceID string,
-) *Controller {
-	if deviceID == "" {
-		deviceID = "controller-1"
+// newControllerForTest creates a Controller without starting the scheduler or
+// background goroutine, so tests can call collectAndPublish synchronously
+// without racing.
+func newControllerForTest(batteries []*batteryRunner, connector BatteryConnector) *Controller {
+	byID := make(map[string]*batteryRunner, len(batteries))
+	for _, battery := range batteries {
+		byID[battery.id] = battery
 	}
 	return &Controller{
-		collector:           collector,
-		publisher:           publisher,
-		prometheusCollector: prometheusCollector,
-		deviceID:            deviceID,
+		batteries: batteries,
+		byID:      byID,
+		connector: connector,
 	}
 }
 
@@ -136,30 +105,49 @@ func NewControllerFromConfig(config Configuration, publisher publish.MessagePubl
 		return &Controller{}, nil
 	}
 
-	if config.Address == "" {
-		log.Warn("voltgo enabled but no battery address provided")
+	batteryConfigs, err := config.ResolveBatteries()
+	if err != nil {
+		log.Warnf("voltgo enabled but not usable: %s", err)
+		return &Controller{}, nil
+	}
+	if len(batteryConfigs) == 0 {
+		log.Warn("voltgo enabled but no batteries configured")
 		return &Controller{}, nil
 	}
 
+	if deviceID == "" {
+		deviceID = "controller-1"
+	}
+
+	// One adapter is shared by every battery. BLE hardware exposes a single
+	// adapter per host, and the collectors serialise their use of it.
 	connector, err := NewBLEConnector()
 	if err != nil {
 		return nil, err
 	}
 
-	collector := NewCollector(connector, config.Address, config.GetConnectTimeout())
 	prometheusCollector := NewPrometheusCollector()
+	connectTimeout := config.GetConnectTimeout()
 
-	log.Infof("voltgo battery configured at %s", config.Address)
+	runners := make([]*batteryRunner, 0, len(batteryConfigs))
+	for _, batteryConfig := range batteryConfigs {
+		collector := NewCollector(connector, batteryConfig.Address, connectTimeout)
+		runners = append(runners, newBatteryRunner(
+			batteryConfig.ID, batteryConfig.Address, collector, publisher, prometheusCollector, deviceID,
+		))
+		log.Infof("voltgo battery %q configured at %s", batteryConfig.ID, batteryConfig.Address)
+	}
 
-	return NewController(
-		collector,
-		publisher,
-		prometheusCollector,
-		deviceID,
-		config.PublishPeriod,
-	)
+	return NewController(runners, connector, config.PublishPeriod)
 }
 
+// collectAndPublish runs one collection cycle across every battery.
+//
+// Batteries are collected one after another rather than concurrently: the
+// host has a single BLE adapter, BlueZ limits concurrent links, and the BMS is
+// timing-sensitive enough that overlapping connects provoke the connection
+// aborts that voltgo v0.2.1 fixed. The cost is that the publish period has to
+// accommodate the sum of the per-battery connect-and-read times.
 func (v *Controller) collectAndPublish() {
 	// Check if a collection is already in progress
 	v.collectMutex.Lock()
@@ -178,89 +166,38 @@ func (v *Controller) collectAndPublish() {
 		v.collectMutex.Unlock()
 	}()
 
-	log.Debug("collecting and publishing metrics for voltgo controller")
-
-	ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
-	defer cancel()
-
-	status, err := v.collector.GetStatus(ctx)
-	if err != nil {
-		log.Errorf("failed to collect metrics from voltgo battery: %s", err)
-		v.prometheusCollector.IncrementFailures()
-
-		// Publish failure metric to message broker
-		failureMetric := CreateCollectionFailureMetric()
-		payload, err := failureMetric.ToJSON()
-		if err != nil {
-			log.Errorf("failed to marshal failure metric: %s", err)
-			return
-		}
-
-		topicSuffix := fmt.Sprintf("%s/%s/%s", v.deviceID, namespace, failureMetric.Name)
-		v.publisher.Publish(topicSuffix, payload)
-		log.Debugf("published failure metric to %s", topicSuffix)
-
-		return
+	for _, battery := range v.batteries {
+		// Each battery gets its own timeout so one unreachable battery
+		// burns its own budget and not the whole cycle's.
+		ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
+		battery.collectAndPublish(ctx)
+		cancel()
 	}
-
-	v.lastStatusMutex.Lock()
-	v.lastStatus = status
-	v.lastStatusMutex.Unlock()
-
-	v.prometheusCollector.SetMetrics(status)
-
-	// Fetch static battery info once, now that a connection is up
-	v.fetchInfoOnce(ctx)
-
-	// Convert status to individual metrics
-	metrics := ConvertStatusToMetrics(status)
-
-	// Publish each metric individually
-	for _, metric := range metrics {
-		payload, err := metric.ToJSON()
-		if err != nil {
-			log.Errorf("failed to marshal metric %s for publishing: %s", metric.Name, err)
-			continue
-		}
-
-		// Topic format: {deviceId}/voltgo/{metric-name}
-		topicSuffix := fmt.Sprintf("%s/%s/%s", v.deviceID, namespace, metric.Name)
-		v.publisher.Publish(topicSuffix, payload)
-
-		log.Debugf("published metric %s to %s", metric.Name, topicSuffix)
-	}
-
-	log.Debug("collection done for voltgo controller")
 }
 
-// fetchInfoOnce caches static battery info on the first successful collection
-// cycle. Failures are logged but never fail the cycle - the next cycle retries.
-func (v *Controller) fetchInfoOnce(ctx context.Context) {
-	v.lastStatusMutex.RLock()
-	cached := v.lastInfo != nil
-	v.lastStatusMutex.RUnlock()
-	if cached {
-		return
+// IndexGet lists the configured batteries. It answers 200 with a possibly
+// empty list as soon as the controller is running, so the frontend can tell
+// "voltgo is configured, batteries are still connecting" from the 404 that
+// means no voltgo controller exists at all.
+func (v *Controller) IndexGet() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		refs := make([]BatteryRef, 0, len(v.batteries))
+		for _, battery := range v.batteries {
+			refs = append(refs, BatteryRef{ID: battery.id, Address: battery.address})
+		}
+		c.JSON(http.StatusOK, BatteryIndex{Batteries: refs})
 	}
-
-	info, err := v.collector.GetInfo(ctx)
-	if err != nil {
-		log.Warnf("failed to read voltgo battery info: %s", err)
-		return
-	}
-
-	v.lastStatusMutex.Lock()
-	v.lastInfo = info
-	v.lastStatusMutex.Unlock()
-	log.Debugf("cached voltgo battery info: %s %.1fV %.0fAh", info.Chemistry, info.NominalVoltage, info.CapacityAh)
 }
 
 func (v *Controller) MetricsGet() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		v.lastStatusMutex.RLock()
-		status := v.lastStatus
-		v.lastStatusMutex.RUnlock()
+		battery, ok := v.byID[c.Param("id")]
+		if !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "unknown battery"})
+			return
+		}
 
+		status := battery.status()
 		if status == nil {
 			c.JSON(http.StatusNoContent, gin.H{})
 			return
@@ -271,10 +208,13 @@ func (v *Controller) MetricsGet() gin.HandlerFunc {
 
 func (v *Controller) InfoGet() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		v.lastStatusMutex.RLock()
-		info := v.lastInfo
-		v.lastStatusMutex.RUnlock()
+		battery, ok := v.byID[c.Param("id")]
+		if !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "unknown battery"})
+			return
+		}
 
+		info := battery.info()
 		if info == nil {
 			c.JSON(http.StatusNoContent, gin.H{})
 			return
@@ -284,27 +224,44 @@ func (v *Controller) InfoGet() gin.HandlerFunc {
 }
 
 func (v *Controller) RegisterEndpoints(r *gin.Engine) {
-	if v.collector == nil {
+	if len(v.batteries) == 0 {
 		return
 	}
 
 	prefix := fmt.Sprintf("/api/%s", namespace)
 
-	r.GET(fmt.Sprintf("%s/metrics", prefix), v.MetricsGet())
-	r.GET(fmt.Sprintf("%s/info", prefix), v.InfoGet())
+	r.GET(prefix, v.IndexGet())
+	r.GET(fmt.Sprintf("%s/:id/metrics", prefix), v.MetricsGet())
+	r.GET(fmt.Sprintf("%s/:id/info", prefix), v.InfoGet())
 }
 
 func (v *Controller) Enabled() bool {
-	return v.collector != nil
+	return len(v.batteries) > 0
 }
 
+// Close stops collection, disconnects every battery, and then releases the
+// shared BLE adapter once.
 func (v *Controller) Close() error {
 	if v.scheduler != nil {
 		v.scheduler.Stop()
 		log.Debug("voltgo scheduler stopped")
 	}
-	if v.collector != nil {
-		return v.collector.Close()
+
+	var firstErr error
+	for _, battery := range v.batteries {
+		if err := battery.close(); err != nil {
+			log.Errorf("failed to close voltgo battery %s: %v", battery.id, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
 	}
-	return nil
+
+	if v.connector != nil {
+		if err := v.connector.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
 }

--- a/internal/controllers/voltgo/voltgo_test.go
+++ b/internal/controllers/voltgo/voltgo_test.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/lumberbarons/solar-controller/internal/publish"
 	"github.com/lumberbarons/solar-controller/internal/testutil"
 	"github.com/lumberbarons/voltgo/battery"
 )
@@ -46,16 +48,31 @@ func newFailingCollector() *Collector {
 	return NewCollector(mockConnector, "AA:BB:CC:DD:EE:FF", 10*time.Second)
 }
 
+// newTestController wires a controller around one battery, matching the
+// single-battery shape most behavioural assertions only need.
+func newTestController(
+	collector *Collector,
+	publisher publish.MessagePublisher,
+	metrics MetricsCollector,
+	deviceID string,
+) (*Controller, *batteryRunner) {
+	runner := newBatteryRunner("bank-a", "AA:BB:CC:DD:EE:FF", collector, publisher, metrics, deviceID)
+	return newControllerForTest([]*batteryRunner{runner}, &MockBatteryConnector{}), runner
+}
+
 func TestController_CollectAndPublish(t *testing.T) {
 	t.Run("publishes failure metric when collection fails", func(t *testing.T) {
 		mockMetrics := &MockMetricsCollector{}
 		mockPublisher := &testutil.MockMessagePublisher{}
 
-		controller := newControllerForTest(newFailingCollector(), mockPublisher, mockMetrics, "test-device-1")
+		controller, _ := newTestController(newFailingCollector(), mockPublisher, mockMetrics, "test-device-1")
 		controller.collectAndPublish()
 
 		if mockMetrics.FailuresCount != 1 {
 			t.Errorf("Expected FailuresCount = 1, got %d", mockMetrics.FailuresCount)
+		}
+		if len(mockMetrics.FailureIDs) != 1 || mockMetrics.FailureIDs[0] != "bank-a" {
+			t.Errorf("failure was not attributed to a battery: %v", mockMetrics.FailureIDs)
 		}
 
 		if len(mockPublisher.PublishCalls) != 1 {
@@ -63,7 +80,7 @@ func TestController_CollectAndPublish(t *testing.T) {
 		}
 
 		call := mockPublisher.PublishCalls[0]
-		expectedTopicSuffix := "test-device-1/voltgo/collection-failure"
+		expectedTopicSuffix := "test-device-1/voltgo/bank-a/collection-failure"
 		if call.TopicSuffix != expectedTopicSuffix {
 			t.Errorf("Expected topic suffix %q, got %q", expectedTopicSuffix, call.TopicSuffix)
 		}
@@ -85,7 +102,7 @@ func TestController_CollectAndPublish(t *testing.T) {
 		mockMetrics := &MockMetricsCollector{}
 		mockPublisher := &testutil.MockMessagePublisher{}
 
-		controller := newControllerForTest(collector, mockPublisher, mockMetrics, "test-device-1")
+		controller, runner := newTestController(collector, mockPublisher, mockMetrics, "test-device-1")
 		controller.collectAndPublish()
 
 		if mockMetrics.FailuresCount != 0 {
@@ -93,7 +110,13 @@ func TestController_CollectAndPublish(t *testing.T) {
 		}
 
 		if len(mockMetrics.SetMetricsCalls) != 1 {
-			t.Errorf("Expected 1 SetMetrics call, got %d", len(mockMetrics.SetMetricsCalls))
+			t.Fatalf("Expected 1 SetMetrics call, got %d", len(mockMetrics.SetMetricsCalls))
+		}
+		if got := mockMetrics.SetMetricsCalls[0].BatteryID; got != "bank-a" {
+			t.Errorf("SetMetrics battery id = %q, want %q", got, "bank-a")
+		}
+		if got := mockMetrics.SetMetricsCalls[0].Status.Voltage; got != 13.28 {
+			t.Errorf("SetMetrics status voltage = %v, want 13.28", got)
 		}
 
 		if len(mockPublisher.PublishCalls) != 8 {
@@ -113,7 +136,7 @@ func TestController_CollectAndPublish(t *testing.T) {
 		}
 		for _, expectedMetric := range metricNames {
 			found := false
-			expectedSuffix := "test-device-1/voltgo/" + expectedMetric
+			expectedSuffix := "test-device-1/voltgo/bank-a/" + expectedMetric
 			for _, call := range mockPublisher.PublishCalls {
 				if call.TopicSuffix == expectedSuffix {
 					found = true
@@ -135,7 +158,7 @@ func TestController_CollectAndPublish(t *testing.T) {
 			{"battery-current", -2.5, "amperes"},
 		}
 		for _, pc := range payloadChecks {
-			suffix := "test-device-1/voltgo/" + pc.metric
+			suffix := "test-device-1/voltgo/bank-a/" + pc.metric
 			for _, call := range mockPublisher.PublishCalls {
 				if call.TopicSuffix == suffix {
 					var payload MetricPayload
@@ -153,17 +176,14 @@ func TestController_CollectAndPublish(t *testing.T) {
 			}
 		}
 
-		controller.lastStatusMutex.RLock()
-		lastStatus := controller.lastStatus
-		controller.lastStatusMutex.RUnlock()
-		if lastStatus == nil {
+		if runner.status() == nil {
 			t.Error("lastStatus should be cached after successful collection")
 		}
 	})
 
 	t.Run("fetches battery info once and caches it", func(t *testing.T) {
 		collector, mockBattery, _ := newWorkingCollector()
-		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller, runner := newTestController(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
 
 		controller.collectAndPublish()
 		controller.collectAndPublish()
@@ -172,9 +192,7 @@ func TestController_CollectAndPublish(t *testing.T) {
 			t.Errorf("GetInfo calls = %d, want 1 (info should be cached after first fetch)", mockBattery.GetInfoCalls)
 		}
 
-		controller.lastStatusMutex.RLock()
-		info := controller.lastInfo
-		controller.lastStatusMutex.RUnlock()
+		info := runner.info()
 		if info == nil {
 			t.Fatal("lastInfo should be cached")
 		}
@@ -191,7 +209,7 @@ func TestController_CollectAndPublish(t *testing.T) {
 
 		mockMetrics := &MockMetricsCollector{}
 		mockPublisher := &testutil.MockMessagePublisher{}
-		controller := newControllerForTest(collector, mockPublisher, mockMetrics, "test-device-1")
+		controller, runner := newTestController(collector, mockPublisher, mockMetrics, "test-device-1")
 
 		controller.collectAndPublish()
 
@@ -208,11 +226,139 @@ func TestController_CollectAndPublish(t *testing.T) {
 		}
 		controller.collectAndPublish()
 
-		controller.lastStatusMutex.RLock()
-		info := controller.lastInfo
-		controller.lastStatusMutex.RUnlock()
-		if info == nil {
+		if runner.info() == nil {
 			t.Error("lastInfo should be cached after retry")
+		}
+	})
+}
+
+// newMultiBatteryController wires three batteries onto one controller. The
+// middle one is unreachable, which is the case the deployment actually hits:
+// four packs on one BLE bus, of which some are not advertising.
+func newMultiBatteryController(
+	publisher publish.MessagePublisher,
+	metrics MetricsCollector,
+) (*Controller, map[string]*MockBatteryClient) {
+	clients := make(map[string]*MockBatteryClient, 2)
+
+	newRunner := func(id, address string, fail bool) *batteryRunner {
+		if fail {
+			connector := &MockBatteryConnector{
+				ConnectFunc: func(_ context.Context, addr string) (BatteryClient, error) {
+					return nil, errors.New("no advertisement from " + addr)
+				},
+			}
+			collector := NewCollector(connector, address, time.Second)
+			return newBatteryRunner(id, address, collector, publisher, metrics, "test-device-1")
+		}
+
+		client := &MockBatteryClient{
+			GetStatusFunc: func(_ context.Context) (*battery.Status, error) {
+				return testBatteryStatus(), nil
+			},
+			GetInfoFunc: func(_ context.Context) (*battery.Info, error) {
+				return &battery.Info{Chemistry: "LiFePO4", NominalVoltage: 12.8, CapacityAh: 100}, nil
+			},
+		}
+		clients[id] = client
+		connector := &MockBatteryConnector{
+			ConnectFunc: func(_ context.Context, _ string) (BatteryClient, error) {
+				return client, nil
+			},
+		}
+		collector := NewCollector(connector, address, time.Second)
+		return newBatteryRunner(id, address, collector, publisher, metrics, "test-device-1")
+	}
+
+	runners := []*batteryRunner{
+		newRunner("bank-a", "AA:AA:AA:AA:AA:01", false),
+		newRunner("bank-b", "AA:AA:AA:AA:AA:02", true),
+		newRunner("bank-c", "AA:AA:AA:AA:AA:03", false),
+	}
+
+	return newControllerForTest(runners, &MockBatteryConnector{}), clients
+}
+
+func TestController_MultipleBatteries(t *testing.T) {
+	t.Run("every battery is collected and published under its own id", func(t *testing.T) {
+		mockMetrics := &MockMetricsCollector{}
+		mockPublisher := &testutil.MockMessagePublisher{}
+
+		controller, clients := newMultiBatteryController(mockPublisher, mockMetrics)
+		controller.collectAndPublish()
+
+		for _, id := range []string{"bank-a", "bank-c"} {
+			if clients[id].GetStatusCalls != 1 {
+				t.Errorf("battery %s GetStatus calls = %d, want 1", id, clients[id].GetStatusCalls)
+			}
+		}
+
+		// Eight metrics each for the two reachable batteries, one failure
+		// metric for the third.
+		if len(mockPublisher.PublishCalls) != 17 {
+			t.Fatalf("publish calls = %d, want 17", len(mockPublisher.PublishCalls))
+		}
+
+		perBattery := map[string]int{}
+		for _, call := range mockPublisher.PublishCalls {
+			parts := strings.Split(call.TopicSuffix, "/")
+			if len(parts) != 4 {
+				t.Fatalf("topic %q does not have the {device}/voltgo/{battery}/{metric} shape", call.TopicSuffix)
+			}
+			if parts[1] != "voltgo" {
+				t.Errorf("topic %q: segment 2 = %q, want voltgo", call.TopicSuffix, parts[1])
+			}
+			perBattery[parts[2]]++
+		}
+
+		want := map[string]int{"bank-a": 8, "bank-b": 1, "bank-c": 8}
+		for id, wantCount := range want {
+			if perBattery[id] != wantCount {
+				t.Errorf("battery %s published %d metrics, want %d", id, perBattery[id], wantCount)
+			}
+		}
+	})
+
+	t.Run("one battery failing does not stop the others", func(t *testing.T) {
+		mockMetrics := &MockMetricsCollector{}
+		mockPublisher := &testutil.MockMessagePublisher{}
+
+		controller, _ := newMultiBatteryController(mockPublisher, mockMetrics)
+		controller.collectAndPublish()
+
+		if mockMetrics.FailuresCount != 1 {
+			t.Errorf("FailuresCount = %d, want 1", mockMetrics.FailuresCount)
+		}
+		if len(mockMetrics.FailureIDs) != 1 || mockMetrics.FailureIDs[0] != "bank-b" {
+			t.Errorf("failure ids = %v, want [bank-b]", mockMetrics.FailureIDs)
+		}
+
+		// bank-c is collected after the battery that fails, so its presence
+		// here is what proves the cycle carried on past the failure.
+		got := mockMetrics.metricsBatteryIDs()
+		want := []string{"bank-a", "bank-c"}
+		if len(got) != len(want) {
+			t.Fatalf("SetMetrics battery ids = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("SetMetrics battery ids = %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("each battery caches its own status independently", func(t *testing.T) {
+		controller, _ := newMultiBatteryController(&testutil.MockMessagePublisher{}, &MockMetricsCollector{})
+		controller.collectAndPublish()
+
+		if controller.byID["bank-a"].status() == nil {
+			t.Error("bank-a should have a cached status")
+		}
+		if controller.byID["bank-b"].status() != nil {
+			t.Error("bank-b never collected successfully, so it should have no cached status")
+		}
+		if controller.byID["bank-c"].status() == nil {
+			t.Error("bank-c should have a cached status")
 		}
 	})
 }
@@ -226,16 +372,19 @@ func TestController_Endpoints(t *testing.T) {
 		return router
 	}
 
+	get := func(router *gin.Engine, path string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		return w
+	}
+
 	t.Run("metrics and info return 204 before first collection", func(t *testing.T) {
 		collector, _, _ := newWorkingCollector()
-		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller, _ := newTestController(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
 		router := newRouter(controller)
 
-		for _, path := range []string{"/api/voltgo/metrics", "/api/voltgo/info"} {
-			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, path, nil)
-			router.ServeHTTP(w, req)
-			if w.Code != http.StatusNoContent {
+		for _, path := range []string{"/api/voltgo/bank-a/metrics", "/api/voltgo/bank-a/info"} {
+			if w := get(router, path); w.Code != http.StatusNoContent {
 				t.Errorf("GET %s status = %d, want %d", path, w.Code, http.StatusNoContent)
 			}
 		}
@@ -243,16 +392,13 @@ func TestController_Endpoints(t *testing.T) {
 
 	t.Run("metrics returns last status including cells", func(t *testing.T) {
 		collector, _, _ := newWorkingCollector()
-		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller, _ := newTestController(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
 		controller.collectAndPublish()
 		router := newRouter(controller)
 
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/api/voltgo/metrics", nil)
-		router.ServeHTTP(w, req)
-
+		w := get(router, "/api/voltgo/bank-a/metrics")
 		if w.Code != http.StatusOK {
-			t.Fatalf("GET /api/voltgo/metrics status = %d, want %d", w.Code, http.StatusOK)
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 		}
 
 		var status BatteryStatus
@@ -269,16 +415,13 @@ func TestController_Endpoints(t *testing.T) {
 
 	t.Run("info returns cached battery info", func(t *testing.T) {
 		collector, _, _ := newWorkingCollector()
-		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller, _ := newTestController(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
 		controller.collectAndPublish()
 		router := newRouter(controller)
 
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/api/voltgo/info", nil)
-		router.ServeHTTP(w, req)
-
+		w := get(router, "/api/voltgo/bank-a/info")
 		if w.Code != http.StatusOK {
-			t.Fatalf("GET /api/voltgo/info status = %d, want %d", w.Code, http.StatusOK)
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 		}
 
 		var info BatteryInfo
@@ -293,15 +436,64 @@ func TestController_Endpoints(t *testing.T) {
 		}
 	})
 
-	t.Run("disabled controller registers no endpoints", func(t *testing.T) {
-		controller := &Controller{}
+	t.Run("index lists every configured battery", func(t *testing.T) {
+		controller, _ := newMultiBatteryController(&testutil.MockMessagePublisher{}, &MockMetricsCollector{})
 		router := newRouter(controller)
 
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/api/voltgo/metrics", nil)
-		router.ServeHTTP(w, req)
-		if w.Code != http.StatusNotFound {
-			t.Errorf("GET /api/voltgo/metrics on disabled controller status = %d, want %d", w.Code, http.StatusNotFound)
+		w := get(router, "/api/voltgo")
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /api/voltgo status = %d, want %d", w.Code, http.StatusOK)
+		}
+
+		var index BatteryIndex
+		if err := json.Unmarshal(w.Body.Bytes(), &index); err != nil {
+			t.Fatalf("failed to unmarshal index: %v", err)
+		}
+
+		ids := make([]string, 0, len(index.Batteries))
+		addressByID := map[string]string{}
+		for _, ref := range index.Batteries {
+			ids = append(ids, ref.ID)
+			addressByID[ref.ID] = ref.Address
+		}
+		sort.Strings(ids)
+
+		want := []string{"bank-a", "bank-b", "bank-c"}
+		if len(ids) != len(want) {
+			t.Fatalf("index ids = %v, want %v", ids, want)
+		}
+		for i := range want {
+			if ids[i] != want[i] {
+				t.Fatalf("index ids = %v, want %v", ids, want)
+			}
+		}
+
+		// The unreachable battery must still be listed: the panel for it is
+		// what shows an operator that it exists and is not reporting.
+		if addressByID["bank-b"] != "AA:AA:AA:AA:AA:02" {
+			t.Errorf("bank-b address = %q, want AA:AA:AA:AA:AA:02", addressByID["bank-b"])
+		}
+	})
+
+	t.Run("unknown battery id returns 404", func(t *testing.T) {
+		collector, _, _ := newWorkingCollector()
+		controller, _ := newTestController(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		router := newRouter(controller)
+
+		for _, path := range []string{"/api/voltgo/nope/metrics", "/api/voltgo/nope/info"} {
+			if w := get(router, path); w.Code != http.StatusNotFound {
+				t.Errorf("GET %s status = %d, want %d", path, w.Code, http.StatusNotFound)
+			}
+		}
+	})
+
+	t.Run("disabled controller registers no endpoints", func(t *testing.T) {
+		router := newRouter(&Controller{})
+
+		for _, path := range []string{"/api/voltgo", "/api/voltgo/bank-a/metrics"} {
+			if w := get(router, path); w.Code != http.StatusNotFound {
+				t.Errorf("GET %s on disabled controller status = %d, want %d", path, w.Code, http.StatusNotFound)
+			}
 		}
 	})
 }
@@ -313,9 +505,9 @@ func TestController_Enabled(t *testing.T) {
 	}
 
 	collector, _, _ := newWorkingCollector()
-	enabled := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+	enabled, _ := newTestController(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
 	if !enabled.Enabled() {
-		t.Error("controller with a collector should be enabled")
+		t.Error("controller with a battery should be enabled")
 	}
 }
 
@@ -328,8 +520,11 @@ func TestController_Close(t *testing.T) {
 	})
 
 	t.Run("close disconnects battery and releases adapter", func(t *testing.T) {
-		collector, mockBattery, mockConnector := newWorkingCollector()
-		controller := newControllerForTest(collector, &testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		collector, mockBattery, _ := newWorkingCollector()
+		sharedConnector := &MockBatteryConnector{}
+		runner := newBatteryRunner("bank-a", "AA:BB:CC:DD:EE:FF", collector,
+			&testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1")
+		controller := newControllerForTest([]*batteryRunner{runner}, sharedConnector)
 		controller.collectAndPublish()
 
 		if err := controller.Close(); err != nil {
@@ -338,30 +533,73 @@ func TestController_Close(t *testing.T) {
 		if mockBattery.DisconnectCalls != 1 {
 			t.Errorf("Disconnect calls = %d, want 1", mockBattery.DisconnectCalls)
 		}
-		if mockConnector.CloseCalls != 1 {
-			t.Errorf("connector Close calls = %d, want 1", mockConnector.CloseCalls)
+		if sharedConnector.CloseCalls != 1 {
+			t.Errorf("connector Close calls = %d, want 1", sharedConnector.CloseCalls)
+		}
+	})
+
+	// The BLE adapter is shared across every battery, so closing the
+	// controller must release it once - not once per battery, which would
+	// double-free the adapter.
+	t.Run("shared adapter is released exactly once for several batteries", func(t *testing.T) {
+		sharedConnector := &MockBatteryConnector{
+			ConnectFunc: func(_ context.Context, _ string) (BatteryClient, error) {
+				return &MockBatteryClient{}, nil
+			},
+		}
+
+		runners := make([]*batteryRunner, 0, 3)
+		for _, id := range []string{"bank-a", "bank-b", "bank-c"} {
+			collector := NewCollector(sharedConnector, "AA:AA:AA:AA:AA:01", time.Second)
+			runners = append(runners, newBatteryRunner(id, "AA:AA:AA:AA:AA:01", collector,
+				&testutil.MockMessagePublisher{}, &MockMetricsCollector{}, "test-device-1"))
+		}
+
+		controller := newControllerForTest(runners, sharedConnector)
+		if err := controller.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		if sharedConnector.CloseCalls != 1 {
+			t.Errorf("connector Close calls = %d, want 1", sharedConnector.CloseCalls)
 		}
 	})
 }
 
 func TestNewControllerFromConfig_Disabled(t *testing.T) {
-	t.Run("disabled via configuration", func(t *testing.T) {
-		controller, err := NewControllerFromConfig(Configuration{Enabled: false}, &testutil.MockMessagePublisher{}, "test-device-1")
-		if err != nil {
-			t.Fatalf("NewControllerFromConfig() error = %v", err)
-		}
-		if controller.Enabled() {
-			t.Error("controller should be disabled")
-		}
-	})
+	tests := []struct {
+		name   string
+		config Configuration
+	}{
+		{"disabled via configuration", Configuration{Enabled: false}},
+		{"enabled but no battery configured", Configuration{Enabled: true}},
+		{
+			name: "enabled but a battery has no address",
+			config: Configuration{
+				Enabled:   true,
+				Batteries: []BatteryConfiguration{{ID: "bank-a"}},
+			},
+		},
+		{
+			name: "enabled but two batteries share an id",
+			config: Configuration{
+				Enabled: true,
+				Batteries: []BatteryConfiguration{
+					{ID: "bank-a", Address: "AA:AA:AA:AA:AA:01"},
+					{ID: "bank-a", Address: "AA:AA:AA:AA:AA:02"},
+				},
+			},
+		},
+	}
 
-	t.Run("enabled but missing address", func(t *testing.T) {
-		controller, err := NewControllerFromConfig(Configuration{Enabled: true}, &testutil.MockMessagePublisher{}, "test-device-1")
-		if err != nil {
-			t.Fatalf("NewControllerFromConfig() error = %v", err)
-		}
-		if controller.Enabled() {
-			t.Error("controller should be disabled when address is missing")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, err := NewControllerFromConfig(tt.config, &testutil.MockMessagePublisher{}, "test-device-1")
+			if err != nil {
+				t.Fatalf("NewControllerFromConfig() error = %v", err)
+			}
+			if controller.Enabled() {
+				t.Error("controller should be disabled")
+			}
+		})
+	}
 }

--- a/internal/publishers/remotewrite/publisher.go
+++ b/internal/publishers/remotewrite/publisher.go
@@ -123,18 +123,32 @@ func (p *Publisher) Publish(topicSuffix, payload string) {
 }
 
 // parseMetric converts a topic suffix and JSON payload into metric data.
-// Topic format: {deviceId}/{controller}/{metric-name}
+// Topic format: {deviceId}/{controller}/{metric-name}, or
+// {deviceId}/{controller}/{batteryId}/{metric-name} for a controller that
+// drives several devices of the same kind.
 // Example: controller-123/epever/battery-voltage
+//
+//	controller-123/voltgo/bank-a/battery-voltage
 func (p *Publisher) parseMetric(topicSuffix, payload string) (metricData, error) {
 	// Parse topic suffix
 	parts := strings.Split(topicSuffix, "/")
-	if len(parts) != 3 {
-		return metricData{}, fmt.Errorf("invalid topic format, expected 3 parts: %s", topicSuffix)
+	if len(parts) < 3 || len(parts) > 4 {
+		return metricData{}, fmt.Errorf("invalid topic format, expected 3 or 4 parts: %s", topicSuffix)
 	}
 
 	deviceID := parts[0]
 	controller := parts[1]
+
+	// The optional third segment identifies one device among several on the
+	// same controller. It becomes a `battery` label rather than part of the
+	// metric name, so the remote-written series match the ones the /metrics
+	// scrape endpoint exposes for the same reading.
+	batteryID := ""
 	metricNameKebab := parts[2]
+	if len(parts) == 4 {
+		batteryID = parts[2]
+		metricNameKebab = parts[3]
+	}
 
 	// Convert kebab-case to snake_case for Prometheus naming
 	metricNameSnake := strings.ReplaceAll(metricNameKebab, "-", "_")
@@ -158,6 +172,10 @@ func (p *Publisher) parseMetric(topicSuffix, payload string) (metricData, error)
 	labels := map[string]string{
 		"device_id":  deviceID,
 		"controller": controller,
+	}
+
+	if batteryID != "" {
+		labels["battery"] = batteryID
 	}
 
 	// Add unit as a label if present

--- a/internal/publishers/remotewrite/publisher_test.go
+++ b/internal/publishers/remotewrite/publisher_test.go
@@ -168,6 +168,49 @@ func TestParseMetric(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// A voltgo topic carries a battery segment, because one
+			// controller drives several packs. Without this the whole
+			// controller's metrics would be dropped as malformed.
+			name:        "per-battery topic yields a battery label, not a longer metric name",
+			topicSuffix: "controller-123/voltgo/bank-a/battery-voltage",
+			payload:     `{"value": 13.28, "unit": "volts", "timestamp": 1699000003}`,
+			wantMetric: metricData{
+				metricName: "voltgo_battery_voltage",
+				labels: map[string]string{
+					"device_id":  "controller-123",
+					"controller": "voltgo",
+					"battery":    "bank-a",
+					"unit":       "volts",
+				},
+				value:     13.28,
+				timestamp: 1699000003,
+			},
+			wantErr: false,
+		},
+		{
+			name:        "three-part topic carries no battery label",
+			topicSuffix: "controller-123/epever/battery-voltage",
+			payload:     `{"value": 13.4, "unit": "volts", "timestamp": 1699000004}`,
+			wantMetric: metricData{
+				metricName: "epever_battery_voltage",
+				labels: map[string]string{
+					"device_id":  "controller-123",
+					"controller": "epever",
+					"unit":       "volts",
+				},
+				value:     13.4,
+				timestamp: 1699000004,
+			},
+			wantErr: false,
+		},
+		{
+			name:        "invalid topic format - too many parts",
+			topicSuffix: "controller-123/voltgo/bank-a/cells/battery-voltage",
+			payload:     `{"value": 12.5, "unit": "volts", "timestamp": 1699000000}`,
+			wantErr:     true,
+			errContains: "invalid topic format",
+		},
+		{
 			name:        "invalid topic format - too few parts",
 			topicSuffix: "controller-123/epever",
 			payload:     `{"value": 12.5, "unit": "volts", "timestamp": 1699000000}`,

--- a/scripts/coverage-floors.txt
+++ b/scripts/coverage-floors.txt
@@ -21,11 +21,11 @@ internal/app                         93
 internal/config                      100
 internal/controllers/epever          56
 internal/controllers/epever/parser   97
-internal/controllers/voltgo          81
+internal/controllers/voltgo          83
 internal/publishers                  90
 internal/publishers/file             92
 internal/publishers/mqtt             73
-internal/publishers/remotewrite      84
+internal/publishers/remotewrite      85
 internal/publishers/sns              40
 internal/publishers/solace           34
 

--- a/site/src/api/types.test.ts
+++ b/site/src/api/types.test.ts
@@ -10,7 +10,9 @@ import {
   INFO_FIELDS,
   METRIC_FIELDS,
   TIME_FIELDS,
+  VOLTGO_BATTERY_REF_FIELDS,
   VOLTGO_CELL_FIELDS,
+  VOLTGO_INDEX_FIELDS,
   VOLTGO_INFO_FIELDS,
   VOLTGO_METRIC_FIELDS,
 } from './types';
@@ -60,9 +62,11 @@ describe('API contract', () => {
     ['GET /api/epever/battery-profile', BATTERY_PROFILE_FIELDS],
     ['GET /api/epever/charging-parameters', CHARGING_PARAMETER_FIELDS],
     ['GET /api/epever/time', TIME_FIELDS],
-    ['GET /api/voltgo/metrics', VOLTGO_METRIC_FIELDS],
-    ['GET /api/voltgo/metrics#cells[]', VOLTGO_CELL_FIELDS],
-    ['GET /api/voltgo/info', VOLTGO_INFO_FIELDS],
+    ['GET /api/voltgo', VOLTGO_INDEX_FIELDS],
+    ['GET /api/voltgo#batteries[]', VOLTGO_BATTERY_REF_FIELDS],
+    ['GET /api/voltgo/{id}/metrics', VOLTGO_METRIC_FIELDS],
+    ['GET /api/voltgo/{id}/metrics#cells[]', VOLTGO_CELL_FIELDS],
+    ['GET /api/voltgo/{id}/info', VOLTGO_INFO_FIELDS],
   ])('%s declares the fields the Go handler returns', (endpoint, declared) => {
     expect([...declared].sort()).toEqual(contractFields(endpoint));
   });

--- a/site/src/api/types.ts
+++ b/site/src/api/types.ts
@@ -49,7 +49,29 @@ export const CHARGING_STATUS_LABELS: Record<number, string> = {
   3: 'Equalization',
 };
 
-/** GET /api/voltgo/metrics */
+/**
+ * GET /api/voltgo — the list of configured batteries.
+ *
+ * The panel discovers batteries from this rather than hardcoding them: the
+ * count is a deployment detail, and a 404 here still means no voltgo
+ * controller is running at all.
+ */
+export const VOLTGO_INDEX_FIELDS = ['batteries'] as const;
+
+/** The objects inside the `batteries` array of GET /api/voltgo. */
+export const VOLTGO_BATTERY_REF_FIELDS = ['address', 'id'] as const;
+
+export type VoltgoBatteryRef = {
+  /** Used verbatim in routes, Prometheus labels, and publisher topics. */
+  id: string;
+  address: string;
+};
+
+export type VoltgoIndex = {
+  batteries: VoltgoBatteryRef[];
+};
+
+/** GET /api/voltgo/{id}/metrics */
 export const VOLTGO_METRIC_FIELDS = [
   'cellCount',
   'cells',
@@ -63,7 +85,7 @@ export const VOLTGO_METRIC_FIELDS = [
   'voltage',
 ] as const;
 
-/** The objects inside the `cells` array of GET /api/voltgo/metrics. */
+/** The objects inside the `cells` array of GET /api/voltgo/{id}/metrics. */
 export const VOLTGO_CELL_FIELDS = ['index', 'voltage'] as const;
 
 export type VoltgoCell = {
@@ -94,7 +116,7 @@ export type VoltgoMetrics = {
   [K in (typeof VOLTGO_METRIC_FIELDS)[number]]: VoltgoMetricTypes[K];
 };
 
-/** GET /api/voltgo/info */
+/** GET /api/voltgo/{id}/info */
 export const VOLTGO_INFO_FIELDS = [
   'capacityAh',
   'chemistry',

--- a/site/src/components/voltgo-battery.test.tsx
+++ b/site/src/components/voltgo-battery.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
-import VoltgoBattery from './voltgo-battery';
-import type { VoltgoInfo, VoltgoMetrics } from '../api/types';
+import VoltgoBatteryBank from './voltgo-battery';
+import type { VoltgoBatteryRef, VoltgoInfo, VoltgoMetrics } from '../api/types';
 
 vi.mock('axios', () => {
   const isAxiosError = (error: unknown): boolean =>
@@ -62,10 +62,20 @@ function mockApi(responses: Record<string, { status: number; data?: unknown }>) 
   });
 }
 
+const BANK_A: VoltgoBatteryRef = { id: 'bank-a', address: 'A4:C1:37:43:A4:33' };
+const BANK_B: VoltgoBatteryRef = { id: 'bank-b', address: 'A4:C1:37:43:A4:42' };
+
+/** The index answer for a given set of batteries. */
+const index = (batteries: VoltgoBatteryRef[]) => ({
+  '/api/voltgo': { status: 200, data: { batteries } },
+});
+
+/** One battery, reporting normally: the single-pack deployment. */
 const withMetrics = (metrics: VoltgoMetrics = METRICS) =>
   mockApi({
-    '/api/voltgo/metrics': { status: 200, data: metrics },
-    '/api/voltgo/info': { status: 200, data: INFO },
+    ...index([BANK_A]),
+    '/api/voltgo/bank-a/metrics': { status: 200, data: metrics },
+    '/api/voltgo/bank-a/info': { status: 200, data: INFO },
   });
 
 beforeEach(() => {
@@ -76,7 +86,7 @@ describe('voltgo battery panel', () => {
   it('renders the pack metrics', async () => {
     withMetrics();
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
     expect(screen.getByText('13.31 V')).toBeInTheDocument();
@@ -87,7 +97,7 @@ describe('voltgo battery panel', () => {
   it('shows the battery description once the info endpoint answers', async () => {
     withMetrics();
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     await waitFor(() =>
       expect(screen.getByText('LiFePO4 · 12.8 V · 100 Ah')).toBeInTheDocument(),
@@ -96,11 +106,12 @@ describe('voltgo battery panel', () => {
 
   it('still renders the pack when the info endpoint has no data yet', async () => {
     mockApi({
-      '/api/voltgo/metrics': { status: 200, data: METRICS },
-      '/api/voltgo/info': { status: 204 },
+      ...index([BANK_A]),
+      '/api/voltgo/bank-a/metrics': { status: 200, data: METRICS },
+      '/api/voltgo/bank-a/info': { status: 204 },
     });
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
     expect(screen.queryByText(/LiFePO4/)).not.toBeInTheDocument();
@@ -114,7 +125,7 @@ describe('voltgo battery panel', () => {
   ])('renders current %p as %s (%s)', async (current, displayed, flow) => {
     withMetrics({ ...METRICS, current });
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     await waitFor(() => expect(screen.getByText(displayed)).toBeInTheDocument());
     expect(screen.getByText(flow)).toBeInTheDocument();
@@ -123,7 +134,7 @@ describe('voltgo battery panel', () => {
   it('highlights the highest and lowest cell and reports the spread', async () => {
     withMetrics();
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     await waitFor(() =>
       expect(screen.getByLabelText('Cell 2 · 3.338 V (highest)')).toBeInTheDocument(),
@@ -143,7 +154,7 @@ describe('voltgo battery panel', () => {
       cellCount: 2,
     });
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     await waitFor(() => expect(screen.getByLabelText('Cell 0 · 3.330 V')).toBeInTheDocument());
     expect(screen.queryByLabelText(/highest/)).not.toBeInTheDocument();
@@ -153,17 +164,17 @@ describe('voltgo battery panel', () => {
   it('renders nothing when the controller is disabled', async () => {
     mockApi({});
 
-    const { container } = render(<VoltgoBattery refreshKey={0} />);
+    const { container } = render(<VoltgoBatteryBank refreshKey={0} />);
 
-    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo/metrics'));
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo'));
     await waitFor(() => expect(container).toBeEmptyDOMElement());
-    expect(mockedGet).not.toHaveBeenCalledWith('/api/voltgo/info');
+    expect(mockedGet).not.toHaveBeenCalledWith('/api/voltgo/bank-a/metrics');
   });
 
   it('says it is waiting when no reading has arrived yet', async () => {
-    mockApi({ '/api/voltgo/metrics': { status: 204 } });
+    mockApi({ ...index([BANK_A]), '/api/voltgo/bank-a/metrics': { status: 204 } });
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     expect(
       await screen.findByText('Waiting for the first battery reading.'),
@@ -173,7 +184,7 @@ describe('voltgo battery panel', () => {
   it('reports a failed fetch rather than rendering nothing', async () => {
     mockedGet.mockRejectedValue(httpError(500, 'Internal Server Error'));
 
-    render(<VoltgoBattery refreshKey={0} />);
+    render(<VoltgoBatteryBank refreshKey={0} />);
 
     expect(
       await screen.findByText('Failed to load battery metrics: 500 Internal Server Error'),
@@ -183,12 +194,89 @@ describe('voltgo battery panel', () => {
   it('refetches when refreshKey changes', async () => {
     withMetrics();
 
-    const { rerender } = render(<VoltgoBattery refreshKey={0} />);
+    const { rerender } = render(<VoltgoBatteryBank refreshKey={0} />);
     await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
 
     withMetrics({ ...METRICS, soc: 81 });
-    rerender(<VoltgoBattery refreshKey={1} />);
+    rerender(<VoltgoBatteryBank refreshKey={1} />);
 
     await waitFor(() => expect(screen.getByText('81 %')).toBeInTheDocument());
+  });
+  it('renders one panel per battery in the index', async () => {
+    mockApi({
+      ...index([BANK_A, BANK_B]),
+      '/api/voltgo/bank-a/metrics': { status: 200, data: METRICS },
+      '/api/voltgo/bank-a/info': { status: 200, data: INFO },
+      '/api/voltgo/bank-b/metrics': { status: 200, data: { ...METRICS, soc: 41, voltage: 12.90 } },
+      '/api/voltgo/bank-b/info': { status: 200, data: INFO },
+    });
+
+    render(<VoltgoBatteryBank refreshKey={0} />);
+
+    // Each pack shows its own reading, so a divergent bank is visible rather
+    // than being averaged away or overwritten by whichever answered last.
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+    expect(screen.getByText('41 %')).toBeInTheDocument();
+    expect(screen.getByText('13.31 V')).toBeInTheDocument();
+    expect(screen.getByText('12.9 V')).toBeInTheDocument();
+
+    expect(screen.getByText(/Battery Bank · bank-a/)).toBeInTheDocument();
+    expect(screen.getByText(/Battery Bank · bank-b/)).toBeInTheDocument();
+  });
+
+  it('does not label the panel with an id when there is only one battery', async () => {
+    withMetrics();
+
+    render(<VoltgoBatteryBank refreshKey={0} />);
+
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+    expect(screen.queryByText(/Battery Bank · /)).not.toBeInTheDocument();
+  });
+
+  it('renders the batteries that answer even when one is unreachable', async () => {
+    mockApi({
+      ...index([BANK_A, BANK_B]),
+      '/api/voltgo/bank-a/metrics': { status: 200, data: METRICS },
+      '/api/voltgo/bank-a/info': { status: 200, data: INFO },
+      // bank-b is configured but has never connected.
+      '/api/voltgo/bank-b/metrics': { status: 204 },
+    });
+
+    render(<VoltgoBatteryBank refreshKey={0} />);
+
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+    expect(
+      screen.getByText('Waiting for the first battery reading.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Battery Bank · bank-b/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when the index lists no batteries', async () => {
+    mockApi(index([]));
+
+    const { container } = render(<VoltgoBatteryBank refreshKey={0} />);
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo'));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('refetches the index as well as the panels when refreshKey changes', async () => {
+    withMetrics();
+
+    const { rerender } = render(<VoltgoBatteryBank refreshKey={0} />);
+    await waitFor(() => expect(screen.getByText('74 %')).toBeInTheDocument());
+
+    // A battery added to the configuration and a reload of the service shows
+    // up as a longer index, and must produce a second panel.
+    mockApi({
+      ...index([BANK_A, BANK_B]),
+      '/api/voltgo/bank-a/metrics': { status: 200, data: METRICS },
+      '/api/voltgo/bank-a/info': { status: 200, data: INFO },
+      '/api/voltgo/bank-b/metrics': { status: 200, data: { ...METRICS, soc: 41 } },
+      '/api/voltgo/bank-b/info': { status: 200, data: INFO },
+    });
+    rerender(<VoltgoBatteryBank refreshKey={1} />);
+
+    await waitFor(() => expect(screen.getByText('41 %')).toBeInTheDocument());
   });
 });

--- a/site/src/components/voltgo-battery.tsx
+++ b/site/src/components/voltgo-battery.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { Alert, Box, Chip, Grid, Stack, Typography } from '@mui/material';
 
 import Metric from './metric';
-import type { VoltgoCell, VoltgoInfo, VoltgoMetrics } from '../api/types';
+import type { VoltgoBatteryRef, VoltgoCell, VoltgoIndex, VoltgoInfo, VoltgoMetrics } from '../api/types';
 
 /**
  * Below this many amps the pack is reported as idle rather than charging or
@@ -16,14 +16,21 @@ const IDLE_CURRENT_THRESHOLD_A = 0.05;
 type PanelState =
   /** The first fetch has not settled yet. */
   | { kind: 'loading' }
-  /** No voltgo controller is running: the endpoint is not registered. */
+  /** This battery's routes are gone: it was removed from the configuration. */
   | { kind: 'absent' }
-  /** Enabled, but no successful collection has happened yet (204). */
+  /** Configured, but no successful collection has happened yet (204). */
   | { kind: 'pending' }
   | { kind: 'ready'; metrics: VoltgoMetrics }
   | { kind: 'error'; message: string };
 
-type VoltgoBatteryProps = {
+type BankState =
+  | { kind: 'loading' }
+  /** No voltgo controller is running: the index endpoint is not registered. */
+  | { kind: 'absent' }
+  | { kind: 'ready'; batteries: VoltgoBatteryRef[] }
+  | { kind: 'error'; message: string };
+
+type RefreshProps = {
   /** Changing this triggers a refetch, so the dashboard refresh covers this panel too. */
   refreshKey: number;
 };
@@ -60,18 +67,24 @@ function errorMessage(error: unknown): string {
   return `Failed to load battery metrics: ${(error as Error).message}`;
 }
 
-/**
- * The battery pack reported by the voltgo BLE controller.
- *
- * Renders nothing when that controller is disabled — its endpoints are then
- * unregistered and answer 404 — so a solar-only deployment sees no empty panel.
- */
-function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
+type VoltgoBatteryPanelProps = RefreshProps & {
+  battery: VoltgoBatteryRef;
+  /**
+   * With one battery the id is noise — often just its BLE address. With
+   * several it is the only thing telling the panels apart, so it is shown.
+   */
+  showId: boolean;
+};
+
+/** One battery pack, read from its own per-battery endpoints. */
+function VoltgoBatteryPanel({ battery, showId, refreshKey }: VoltgoBatteryPanelProps) {
   const [state, setState] = useState<PanelState>({ kind: 'loading' });
   const [info, setInfo] = useState<VoltgoInfo | null>(null);
 
+  const { id } = battery;
+
   const fetchInfo = useCallback(() => {
-    axios.get<VoltgoInfo>('/api/voltgo/info')
+    axios.get<VoltgoInfo>(`/api/voltgo/${id}/info`)
       .then(response => {
         // 204 until the first connection has read the static info.
         setInfo(response.status === 204 ? null : response.data);
@@ -80,12 +93,12 @@ function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
         // Info is decoration; the panel is useful without it.
         setInfo(null);
       });
-  }, []);
+  }, [id]);
 
   useEffect(() => {
     let cancelled = false;
 
-    axios.get<VoltgoMetrics>('/api/voltgo/metrics')
+    axios.get<VoltgoMetrics>(`/api/voltgo/${id}/metrics`)
       .then(response => {
         if (cancelled) {
           return;
@@ -105,14 +118,14 @@ function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
           setState({ kind: 'absent' });
           return;
         }
-        console.error('Failed to load voltgo battery metrics:', error);
+        console.error(`Failed to load voltgo battery ${id} metrics:`, error);
         setState({ kind: 'error', message: errorMessage(error) });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [refreshKey, fetchInfo]);
+  }, [id, refreshKey, fetchInfo]);
 
   if (state.kind === 'absent' || state.kind === 'loading') {
     return null;
@@ -120,7 +133,7 @@ function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
 
   const heading = (
     <Typography variant="h6" sx={{ mb: 1, fontWeight: 600, color: '#1b5e20' }}>
-      Battery Bank
+      {showId ? `Battery Bank · ${id}` : 'Battery Bank'}
       {info && (
         <Typography component="span" sx={{ ml: 1, fontSize: '0.875rem', color: 'text.secondary' }}>
           {info.chemistry} · {info.nominalVoltage} V · {info.capacityAh} Ah
@@ -197,7 +210,7 @@ function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
                 <Chip
                   key={cell.index}
                   label={label}
-                  aria-label={`${label}${extreme}`}
+                  aria-label={`${showId ? `${id} ` : ''}${label}${extreme}`}
                   variant="outlined"
                   sx={{
                     borderColor,
@@ -214,4 +227,67 @@ function VoltgoBattery({ refreshKey }: VoltgoBatteryProps) {
   );
 }
 
-export default VoltgoBattery;
+/**
+ * Every battery pack reported by the voltgo BLE controller.
+ *
+ * The batteries come from the index endpoint rather than being hardcoded, so
+ * a deployment with four packs renders four panels without a frontend change.
+ * Renders nothing when the controller is disabled — the index is then
+ * unregistered and answers 404 — so a solar-only deployment sees no empty panel.
+ */
+function VoltgoBatteryBank({ refreshKey }: RefreshProps) {
+  const [state, setState] = useState<BankState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    axios.get<VoltgoIndex>('/api/voltgo')
+      .then(response => {
+        if (cancelled) {
+          return;
+        }
+        setState({ kind: 'ready', batteries: response.data?.batteries ?? [] });
+      })
+      .catch(error => {
+        if (cancelled) {
+          return;
+        }
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          setState({ kind: 'absent' });
+          return;
+        }
+        console.error('Failed to load the voltgo battery list:', error);
+        setState({ kind: 'error', message: errorMessage(error) });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  if (state.kind === 'absent' || state.kind === 'loading') {
+    return null;
+  }
+
+  if (state.kind === 'error') {
+    return <Alert severity="error" sx={{ mb: 2 }}>{state.message}</Alert>;
+  }
+
+  const { batteries } = state;
+  const showId = batteries.length > 1;
+
+  return (
+    <>
+      {batteries.map(battery => (
+        <VoltgoBatteryPanel
+          key={battery.id}
+          battery={battery}
+          showId={showId}
+          refreshKey={refreshKey}
+        />
+      ))}
+    </>
+  );
+}
+
+export default VoltgoBatteryBank;

--- a/site/src/pages/main.test.tsx
+++ b/site/src/pages/main.test.tsx
@@ -146,20 +146,42 @@ describe('dashboard', () => {
   it('hides the battery panel when the voltgo controller is not running', async () => {
     render(<Main />);
 
-    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo/metrics'));
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/voltgo'));
     expect(screen.queryByText('Battery Bank')).not.toBeInTheDocument();
   });
 
   it('shows the battery panel and refreshes it alongside the dashboard', async () => {
-    mockApi({ '/api/voltgo/metrics': VOLTGO_METRICS });
+    mockApi({
+      '/api/voltgo': { batteries: [{ id: 'bank-a', address: 'A4:C1:37:43:A4:33' }] },
+      '/api/voltgo/bank-a/metrics': VOLTGO_METRICS,
+    });
 
     render(<Main />);
     await waitFor(() => expect(screen.getByText('Battery Bank')).toBeInTheDocument());
 
-    const before = callCount('/api/voltgo/metrics');
+    const before = callCount('/api/voltgo/bank-a/metrics');
 
     screen.getByRole('button', { name: 'refresh metrics' }).click();
 
-    await waitFor(() => expect(callCount('/api/voltgo/metrics')).toBe(before + 1));
+    await waitFor(() => expect(callCount('/api/voltgo/bank-a/metrics')).toBe(before + 1));
+  });
+
+  it('renders a panel per battery when several are configured', async () => {
+    mockApi({
+      '/api/voltgo': {
+        batteries: [
+          { id: 'bank-a', address: 'A4:C1:37:43:A4:33' },
+          { id: 'bank-b', address: 'A4:C1:37:43:A4:42' },
+        ],
+      },
+      '/api/voltgo/bank-a/metrics': VOLTGO_METRICS,
+      '/api/voltgo/bank-b/metrics': { ...VOLTGO_METRICS, soc: 52 },
+    });
+
+    render(<Main />);
+
+    await waitFor(() => expect(screen.getByText('Battery Bank · bank-a')).toBeInTheDocument());
+    expect(screen.getByText('Battery Bank · bank-b')).toBeInTheDocument();
+    expect(screen.getByText('52 %')).toBeInTheDocument();
   });
 });

--- a/site/src/pages/main.tsx
+++ b/site/src/pages/main.tsx
@@ -6,7 +6,7 @@ import { Grid, Box, Alert, IconButton, Typography } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 
 import Metric from "../components/metric"
-import VoltgoBattery from "../components/voltgo-battery"
+import VoltgoBatteryBank from "../components/voltgo-battery"
 import { CHARGING_STATUS_LABELS, type EpeverMetrics } from '../api/types';
 
 type MainState = {
@@ -121,8 +121,9 @@ class Main extends React.Component<Record<string, never>, MainState> {
             </Grid>
           </Grid>
 
-          {/* Battery bank via the voltgo BLE controller; renders nothing when it is disabled */}
-          <VoltgoBattery refreshKey={this.state.refreshKey} />
+          {/* One panel per battery on the voltgo BLE controller, discovered from
+              /api/voltgo; renders nothing when that controller is disabled */}
+          <VoltgoBatteryBank refreshKey={this.state.refreshKey} />
 
           <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
             <IconButton


### PR DESCRIPTION
### What

Design decisions to settle before implementing — these are the substance of the work,
not the mechanical plumbing:

- **Identity.** Each battery needs a stable, human-meaningful id used consistently in
  routes, Prometheus labels, and topics. BLE address is stable but unreadable; a
  configured `name` per battery is friendlier. Probably: required `name`, defaulting to
  the address if omitted.
- **Endpoint shape.** Likely `/api/voltgo/{id}/metrics` and `/api/voltgo/{id}/info`,
  plus an index at `/api/voltgo` listing configured batteries so the frontend can
  discover them rather than hardcoding four. Note the existing 404-means-disabled
  contract the frontend relies on, and the `204 No Content` before first collection.
- **Prometheus.** Convert the gauges to `GaugeVec` with a `battery` label; `cell_voltage`
  becomes two labels (`battery`, `cell`). Registering per-controller into the default
  registry must stop, or duplicate registration panics.
- **BLE concurrency.** Unknown whether one adapter can usefully hold four concurrent
  links — BlueZ has a connection ceiling and the BMS is sensitive to timing (see the
  `le-connection-abort-by-local` class of failure fixed in voltgo v0.2.1). Serialising
  collection across batteries is the safer default; four sequential connects at ~9s
  cold and ~0.5s warm must fit inside the publish period. Measure before choosing.
- **Backwards compatibility.** Decide whether the existing single `voltgo:` block keeps
  working or is a breaking config change. A list under `voltgo.batteries:` alongside a
  deprecated singular form is the gentler path.

Per-file work items:

- `internal/config/config.go` — a list of battery configs; validate each, and reject
  duplicate ids/addresses
- `internal/app/app.go` — build one controller per configured battery
- `internal/controllers/voltgo/voltgo.go` — per-battery route namespacing; drop the
  package-level `namespace` const as the route source
- `internal/controllers/voltgo/prometheus.go` — `battery` label; shared registry
- `internal/controllers/voltgo/metrics.go` — battery id in the publisher topic
- `site/src/api/types.ts`, `site/src/components/voltgo-battery.tsx`,
  `site/src/pages/main.tsx` — render N panels from the index endpoint
- `docs/api-contract.json` — new endpoint shapes
- `README.md`, `CLAUDE.md` — config examples and topic structure

### Why

Collect from more than one Voltgo battery. The deployment has **four** batteries, and
every layer currently assumes exactly one, so three of them cannot be read at all.

The single-battery assumption is load-bearing in five separate places:

- **Config** takes one `voltgo:` block with one `address`, so a second battery is
  unrepresentable.
- **Bootstrap** builds one controller from that one block.
- **HTTP** registers `/api/voltgo/metrics` and `/api/voltgo/info` from a package-level
  `namespace` const. A second controller would register duplicate routes, which Gin
  panics on.
- **Prometheus** registers `voltgo_*` gauges via `promauto` into the default registry
  with no per-battery label. A second collector panics on duplicate registration, and
  even if it did not, the four batteries would overwrite each other's values.
- **Publisher topics** are `{prefix}/{deviceId}/voltgo/{metric}`, which has no segment
  to distinguish one battery from another.

### Testing

Added `TestController_MultipleBatteries` (three batteries, middle one unreachable), `TestResolveBatteries` (13 cases covering the deprecated singular form, derived ids, duplicate ids/addresses, and unsafe id characters), labelled-series cases in `TestPrometheusCollector`, `TestIndexPayloadMatchesAPIContract`/`TestBatteryRefPayloadMatchesAPIContract`, four-segment topic cases in the remotewrite `parseMetric` table, and five multi-battery cases across `voltgo-battery.test.tsx` and `main.test.tsx`. `go test ./...` passes (12 packages); `make test-coverage` clears the gate with voltgo ratcheted 81 -> 83% and remotewrite 84 -> 85%; `golangci-lint run ./...` reports 0 issues; `tsc --noEmit`, `npm run lint`, and 55 vitest tests pass.

Fixes #187